### PR TITLE
feat(gemini): add dynamic subtypes to inference spans

### DIFF
--- a/src/instrumentation/common/constants.ts
+++ b/src/instrumentation/common/constants.ts
@@ -94,6 +94,7 @@ export const DELEGATION_NAME_PREFIX = Symbol("transfer_to_")
 export const INFERENCE_AGENT_DELEGATION = "delegation"
 export const INFERENCE_TOOL_CALL = "tool_call"
 export const INFERENCE_COMMUNICATION = "turn"
+export const INFERENCE_TURN_END = "turn_end"
 
 export const SPAN_TYPES = {
     GENERIC: "generic",

--- a/src/instrumentation/common/constants.ts
+++ b/src/instrumentation/common/constants.ts
@@ -96,6 +96,9 @@ export const INFERENCE_TOOL_CALL = "tool_call"
 export const INFERENCE_COMMUNICATION = "turn"
 export const INFERENCE_TURN_END = "turn_end"
 
+// Synthesized finish reason — Gemini returns "STOP" for tool-call responses, so we set this when a functionCall part is detected.
+export const GEMINI_FUNCTION_CALL_FINISH_REASON = "FUNCTION_CALL"
+
 export const SPAN_TYPES = {
     GENERIC: "generic",
     AGENTIC_DELEGATION: "agentic.delegation",

--- a/src/instrumentation/common/spanHandler.ts
+++ b/src/instrumentation/common/spanHandler.ts
@@ -163,7 +163,7 @@ export class DefaultSpanHandler implements SpanHandler {
 
     }
 
-    processSpan({ span, instance, args, returnValue, outputProcessor, exception }: {
+    processSpan({ span, instance, args, returnValue, outputProcessor, exception, parentSpan }: {
         span: Span;
         instance: any;
         args: IArguments;
@@ -287,7 +287,29 @@ export class DefaultSpanHandler implements SpanHandler {
             span.setAttribute("span.type", outputProcessor?.type || "generic");
         }
         if (outputProcessor?.subtype) {
-            span.setAttribute("span.subtype", outputProcessor.subtype);
+            // Allow schemas to compute the subtype dynamically from the call
+            // payload (e.g. classify an inference span as "tool_call" vs
+            // "turn_end" based on the model's finish_reason). Static string
+            // subtypes continue to work unchanged.
+            let subtypeValue: any = outputProcessor.subtype;
+            if (typeof subtypeValue === 'function') {
+                try {
+                    subtypeValue = subtypeValue({
+                        instance,
+                        args,
+                        output: returnValue,
+                        response: returnValue,
+                        exception,
+                        parentSpan,
+                    });
+                } catch (e) {
+                    console.error(`Error evaluating subtype accessor: ${e}`);
+                    subtypeValue = undefined;
+                }
+            }
+            if (subtypeValue) {
+                span.setAttribute("span.subtype", subtypeValue);
+            }
         }
         if (spanIndex > 1) {
             span.setAttribute("entity.count", spanIndex - 1);

--- a/src/instrumentation/metamodel/finishType.ts
+++ b/src/instrumentation/metamodel/finishType.ts
@@ -10,7 +10,9 @@ export enum FinishType {
     CONTENT_FILTER = "content_filter",
     ERROR = "error",
     REFUSAL = "refusal",
-    RATE_LIMITED = "rate_limited"
+    RATE_LIMITED = "rate_limited",
+    TOOL_CALL = "tool_call",
+    TOOL_CALL_ERROR = "tool_call_error"
 }
 
 // OpenAI finish reason mapping
@@ -35,6 +37,8 @@ export const ANTHROPIC_FINISH_REASON_MAPPING: Record<string, string> = {
 // Gemini finish reason mapping
 export const GEMINI_FINISH_REASON_MAPPING: Record<string, string | null> = {
     "STOP": FinishType.SUCCESS,
+    "FUNCTION_CALL": FinishType.TOOL_CALL,
+    "MALFORMED_FUNCTION_CALL": FinishType.TOOL_CALL_ERROR,
     "MAX_TOKENS": FinishType.TRUNCATED,
     "SAFETY": FinishType.CONTENT_FILTER,
     "RECITATION": FinishType.CONTENT_FILTER,

--- a/src/instrumentation/metamodel/finishType.ts
+++ b/src/instrumentation/metamodel/finishType.ts
@@ -2,6 +2,7 @@
  * This module provides common finish reason mappings and finish type enums
  * for different AI providers (OpenAI, Anthropic, Gemini, LangChain, LlamaIndex, Azure AI Inference).
  */
+import { GEMINI_FUNCTION_CALL_FINISH_REASON } from "../common/constants";
 
 // Enum for standardized finish types across all AI providers
 export enum FinishType {
@@ -37,7 +38,7 @@ export const ANTHROPIC_FINISH_REASON_MAPPING: Record<string, string> = {
 // Gemini finish reason mapping
 export const GEMINI_FINISH_REASON_MAPPING: Record<string, string | null> = {
     "STOP": FinishType.SUCCESS,
-    "FUNCTION_CALL": FinishType.TOOL_CALL,
+    [GEMINI_FUNCTION_CALL_FINISH_REASON]: FinishType.TOOL_CALL,
     "MALFORMED_FUNCTION_CALL": FinishType.TOOL_CALL_ERROR,
     "MAX_TOKENS": FinishType.TRUNCATED,
     "SAFETY": FinishType.CONTENT_FILTER,

--- a/src/instrumentation/metamodel/gemini/entities/inference.ts
+++ b/src/instrumentation/metamodel/gemini/entities/inference.ts
@@ -1,4 +1,5 @@
 import { mapGeminiFinishReasonToFinishType } from "../../finishType";
+import { INFERENCE_TOOL_CALL, INFERENCE_TURN_END } from "../../../common/constants";
 import {
   extractGeminiEndpoint,
   getStatus,
@@ -9,9 +10,20 @@ import {
 
 function extractFinishReason(response: any): string | null {
   try {
-    // Handle traditional chat.completions.create() format
-    if (response && response.candidates && response.candidates[0] && response.candidates[0].finishReason) {
-      return response.candidates[0].finishReason;
+    if (response && response.candidates && response.candidates[0]) {
+      const candidate = response.candidates[0];
+      // Tool-call detection takes priority: Gemini sets finishReason to
+      // "STOP" even when the model produced a functionCall part, so we
+      // synthesize "FUNCTION_CALL" when any part of the response is a
+      // function-call. That lets the finishReason → finishType mapping
+      // classify it correctly as a tool_call.
+      const parts = candidate.content?.parts;
+      if (Array.isArray(parts) && parts.some((p: any) => p?.functionCall)) {
+        return "FUNCTION_CALL";
+      }
+      if (candidate.finishReason) {
+        return candidate.finishReason;
+      }
     }
   } catch (e) {
     console.warn("Warning: Error occurred in extractFinishReason:", e);
@@ -159,8 +171,26 @@ function extractInferenceOutput(result) {
   }
 }
 
+// Classify an inference call as a tool-call dispatch or a normal end-of-turn
+// response, based on Gemini's finish reason. Used as a dynamic span.subtype
+// so traces can distinguish "the model wanted to call a tool" from "the
+// model produced its final answer for this turn" at a glance.
+function classifyInferenceSubtype(response: any): string {
+  try {
+    const finishReason = extractFinishReason(response);
+    const finishType = mapGeminiFinishReasonToFinishType(finishReason);
+    if (finishType === "tool_call") return INFERENCE_TOOL_CALL;
+  } catch (e) {
+    console.warn("Warning: Error occurred in classifyInferenceSubtype:", e);
+  }
+  return INFERENCE_TURN_END;
+}
+
 export const config = {
   type: "inference",
+  subtype: function ({ response, output }: any) {
+    return classifyInferenceSubtype(response ?? output);
+  },
   attributes: [
     [
       {

--- a/src/instrumentation/metamodel/gemini/entities/inference.ts
+++ b/src/instrumentation/metamodel/gemini/entities/inference.ts
@@ -1,5 +1,9 @@
 import { mapGeminiFinishReasonToFinishType } from "../../finishType";
-import { INFERENCE_TOOL_CALL, INFERENCE_TURN_END } from "../../../common/constants";
+import {
+  GEMINI_FUNCTION_CALL_FINISH_REASON,
+  INFERENCE_TOOL_CALL,
+  INFERENCE_TURN_END,
+} from "../../../common/constants";
 import {
   extractGeminiEndpoint,
   getStatus,
@@ -19,7 +23,7 @@ function extractFinishReason(response: any): string | null {
       // classify it correctly as a tool_call.
       const parts = candidate.content?.parts;
       if (Array.isArray(parts) && parts.some((p: any) => p?.functionCall)) {
-        return "FUNCTION_CALL";
+        return GEMINI_FUNCTION_CALL_FINISH_REASON;
       }
       if (candidate.finishReason) {
         return candidate.finishReason;

--- a/test/unit/gemini.test.ts
+++ b/test/unit/gemini.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import {
+    GEMINI_FINISH_REASON_MAPPING,
+    mapGeminiFinishReasonToFinishType,
+    FinishType,
+} from '../../src/instrumentation/metamodel/finishType';
+import { config as geminiInferenceConfig } from '../../src/instrumentation/metamodel/gemini/entities/inference';
+
+// =============================================================================
+// Gemini finish-reason → finish-type mapping
+// =============================================================================
+describe('Gemini finish-reason mapping', () => {
+    it('maps STOP to success', () => {
+        expect(mapGeminiFinishReasonToFinishType('STOP')).toBe(FinishType.SUCCESS);
+    });
+
+    it('maps FUNCTION_CALL to tool_call', () => {
+        expect(mapGeminiFinishReasonToFinishType('FUNCTION_CALL')).toBe(FinishType.TOOL_CALL);
+    });
+
+    it('maps MALFORMED_FUNCTION_CALL to tool_call_error', () => {
+        expect(mapGeminiFinishReasonToFinishType('MALFORMED_FUNCTION_CALL')).toBe(FinishType.TOOL_CALL_ERROR);
+    });
+
+    it('maps MAX_TOKENS to truncated', () => {
+        expect(mapGeminiFinishReasonToFinishType('MAX_TOKENS')).toBe(FinishType.TRUNCATED);
+    });
+
+    it('maps SAFETY and RECITATION to content_filter', () => {
+        expect(mapGeminiFinishReasonToFinishType('SAFETY')).toBe(FinishType.CONTENT_FILTER);
+        expect(mapGeminiFinishReasonToFinishType('RECITATION')).toBe(FinishType.CONTENT_FILTER);
+    });
+
+    it('maps OTHER to error', () => {
+        expect(mapGeminiFinishReasonToFinishType('OTHER')).toBe(FinishType.ERROR);
+    });
+
+    it('returns null for FINISH_REASON_UNSPECIFIED', () => {
+        expect(mapGeminiFinishReasonToFinishType('FINISH_REASON_UNSPECIFIED')).toBeNull();
+    });
+
+    it('returns null for unknown values', () => {
+        expect(mapGeminiFinishReasonToFinishType('NOT_A_REAL_REASON')).toBeNull();
+    });
+
+    it('returns null for null input', () => {
+        expect(mapGeminiFinishReasonToFinishType(null)).toBeNull();
+    });
+
+    it('mapping table contains both new entries explicitly', () => {
+        // Guard against accidental removal of the new mappings during refactors.
+        expect(GEMINI_FINISH_REASON_MAPPING['FUNCTION_CALL']).toBe(FinishType.TOOL_CALL);
+        expect(GEMINI_FINISH_REASON_MAPPING['MALFORMED_FUNCTION_CALL']).toBe(FinishType.TOOL_CALL_ERROR);
+    });
+});
+
+// =============================================================================
+// Gemini inference schema's dynamic subtype classifier
+// =============================================================================
+describe('Gemini inference schema.subtype classifier', () => {
+    // Schema exports the subtype as a callable that takes { response } and
+    // returns "tool_call" or "turn_end". We invoke it directly with synthetic
+    // Gemini-shaped responses.
+    const classify = (response: any): string => {
+        const subtypeFn = geminiInferenceConfig.subtype as any;
+        return subtypeFn({ response });
+    };
+
+    it('subtype is exposed as a function on the schema', () => {
+        expect(typeof geminiInferenceConfig.subtype).toBe('function');
+    });
+
+    it('classifies a plain text response as turn_end', () => {
+        const response = {
+            candidates: [{
+                finishReason: 'STOP',
+                content: { parts: [{ text: 'hello world' }] },
+            }],
+        };
+        expect(classify(response)).toBe('turn_end');
+    });
+
+    it('classifies a function-call response as tool_call (even when finishReason is STOP)', () => {
+        // This is the critical case: Gemini still emits finishReason="STOP"
+        // for tool-call responses, so the classifier MUST detect via content,
+        // not via finishReason alone.
+        const response = {
+            candidates: [{
+                finishReason: 'STOP',
+                content: {
+                    parts: [{ functionCall: { name: 'book_flight', args: { from: 'SFO' } } }],
+                },
+            }],
+        };
+        expect(classify(response)).toBe('tool_call');
+    });
+
+    it('classifies a mixed text+functionCall response as tool_call', () => {
+        // If ANY part is a function call, the whole response is treated as
+        // tool_call — interleaved text alongside the call doesn't change that.
+        const response = {
+            candidates: [{
+                finishReason: 'STOP',
+                content: {
+                    parts: [
+                        { text: 'Let me look that up.' },
+                        { functionCall: { name: 'book_flight' } },
+                    ],
+                },
+            }],
+        };
+        expect(classify(response)).toBe('tool_call');
+    });
+
+    it('classifies a truncated response as turn_end', () => {
+        const response = {
+            candidates: [{
+                finishReason: 'MAX_TOKENS',
+                content: { parts: [{ text: 'partial output…' }] },
+            }],
+        };
+        expect(classify(response)).toBe('turn_end');
+    });
+
+    it('classifies a MALFORMED_FUNCTION_CALL as turn_end (tool_call_error ≠ tool_call)', () => {
+        // Maps to TOOL_CALL_ERROR finish type, which is NOT equal to "tool_call",
+        // so the classifier's only-when-tool_call branch doesn't fire.
+        const response = {
+            candidates: [{ finishReason: 'MALFORMED_FUNCTION_CALL' }],
+        };
+        expect(classify(response)).toBe('turn_end');
+    });
+
+    it('classifies a SAFETY-blocked response as turn_end', () => {
+        const response = {
+            candidates: [{
+                finishReason: 'SAFETY',
+                content: { parts: [] },
+            }],
+        };
+        expect(classify(response)).toBe('turn_end');
+    });
+
+    it('gracefully falls back to turn_end on missing finishReason', () => {
+        const response = {
+            candidates: [{ content: { parts: [{ text: 'no reason field' }] } }],
+        };
+        expect(classify(response)).toBe('turn_end');
+    });
+
+    it('gracefully falls back to turn_end on empty response object', () => {
+        expect(classify({})).toBe('turn_end');
+    });
+
+    it('gracefully falls back to turn_end on null response', () => {
+        expect(classify(null)).toBe('turn_end');
+    });
+});

--- a/test/unit/spanHandler.test.ts
+++ b/test/unit/spanHandler.test.ts
@@ -294,6 +294,98 @@ describe('DefaultSpanHandler', () => {
       expect(mockSpan.addEvent).toHaveBeenCalledWith('test-event', { test_key: 'test_value' });
     });
 
+    it('should set span.subtype from a static string value', () => {
+      const outputProcessor = [{
+        type: 'inference',
+        subtype: 'tool_call',
+        attributes: [],
+      }];
+
+      spanHandler.processSpan({
+        span: mockSpan,
+        instance: {},
+        args: {} as IArguments,
+        returnValue: {},
+        outputProcessor,
+        wrappedPackage: '',
+      });
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith('span.subtype', 'tool_call');
+    });
+
+    it('should evaluate a callable subtype and set its return value', () => {
+      const subtypeFn = vi.fn().mockReturnValue('turn_end');
+      const outputProcessor = [{
+        type: 'inference',
+        subtype: subtypeFn,
+        attributes: [],
+      }];
+
+      const returnValue = { candidates: [{ finishReason: 'STOP' }] };
+      spanHandler.processSpan({
+        span: mockSpan,
+        instance: { name: 'test-instance' },
+        args: {} as IArguments,
+        returnValue,
+        outputProcessor,
+        wrappedPackage: '',
+      });
+
+      expect(subtypeFn).toHaveBeenCalledTimes(1);
+      const callArg = subtypeFn.mock.calls[0][0];
+      expect(callArg.instance).toEqual({ name: 'test-instance' });
+      expect(callArg.response).toBe(returnValue);
+      expect(callArg.output).toBe(returnValue);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith('span.subtype', 'turn_end');
+    });
+
+    it('should NOT set span.subtype when the callable returns undefined', () => {
+      const subtypeFn = vi.fn().mockReturnValue(undefined);
+      const outputProcessor = [{
+        type: 'inference',
+        subtype: subtypeFn,
+        attributes: [],
+      }];
+
+      spanHandler.processSpan({
+        span: mockSpan,
+        instance: {},
+        args: {} as IArguments,
+        returnValue: {},
+        outputProcessor,
+        wrappedPackage: '',
+      });
+
+      expect(subtypeFn).toHaveBeenCalledTimes(1);
+      const subtypeCall = (mockSpan.setAttribute as ReturnType<typeof vi.fn>).mock.calls
+        .find((c: any[]) => c[0] === 'span.subtype');
+      expect(subtypeCall).toBeUndefined();
+    });
+
+    it('should NOT crash when the callable subtype throws — span just lacks the attribute', () => {
+      const subtypeFn = vi.fn(() => { throw new Error('boom'); });
+      const outputProcessor = [{
+        type: 'inference',
+        subtype: subtypeFn,
+        attributes: [],
+      }];
+
+      const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+      expect(() => spanHandler.processSpan({
+        span: mockSpan,
+        instance: {},
+        args: {} as IArguments,
+        returnValue: {},
+        outputProcessor,
+        wrappedPackage: '',
+      })).not.toThrow();
+
+      const subtypeCall = (mockSpan.setAttribute as ReturnType<typeof vi.fn>).mock.calls
+        .find((c: any[]) => c[0] === 'span.subtype');
+      expect(subtypeCall).toBeUndefined();
+      consoleErr.mockRestore();
+    });
+
     it('should process attributes when they are a nested array structure', () => {
       const mockAccessor = vi.fn().mockReturnValue('test-value');
       const outputProcessor = [{


### PR DESCRIPTION


## Proposed changes

Adds dynamic `tool_call` / `turn_end` subtype to Gemini inference spans

### What changes

- **Engine** (`spanHandler.processSpan`): `outputProcessor.subtype` may now be a function returning a string. Static string subtypes (every existing metamodel) keep working unchanged.
- **Gemini schema**: `subtype` is now `({response}) => "tool_call" | "turn_end"`. The classifier reads Gemini's finish reason, with content-based override that synthesizes `FUNCTION_CALL` when the response contains a `functionCall` part — Gemini sets `finishReason: STOP` even for tool calls, so finishReason alone is insufficient.
- **Finish-reason mapping**: added `FUNCTION_CALL → tool_call` and `MALFORMED_FUNCTION_CALL → tool_call_error` to `GEMINI_FINISH_REASON_MAPPING`. Added `TOOL_CALL` and `TOOL_CALL_ERROR` to the `FinishType` enum.

### Span shape

Every `gemini.generate_content` span now carries one of:
```jsonc
{ "span.subtype": "tool_call" }   // model requested a function call
{ "span.subtype": "turn_end" }    // model produced a final text response
```

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...