### PR TITLE
fix(gemini): capture system input and tool-call output in inference spans

### DIFF
--- a/src/instrumentation/metamodel/gemini/entities/inference.ts
+++ b/src/instrumentation/metamodel/gemini/entities/inference.ts
@@ -12,6 +12,19 @@ import {
 } from "../../utils";
 
 
+// Pulls functionCall parts out of the first candidate — emitted on tool calls /
+// sub-agent delegation. Drives both finish-reason synthesis and output extraction.
+function extractFunctionCalls(response: any): any[] {
+  try {
+    const parts = response?.candidates?.[0]?.content?.parts;
+    if (!Array.isArray(parts)) return [];
+    return parts.map((p: any) => p?.functionCall).filter((fc: any) => fc);
+  } catch (e) {
+    console.warn("Warning: Error occurred in extractFunctionCalls:", e);
+    return [];
+  }
+}
+
 function extractFinishReason(response: any): string | null {
   try {
     if (response && response.candidates && response.candidates[0]) {
@@ -21,8 +34,7 @@ function extractFinishReason(response: any): string | null {
       // synthesize "FUNCTION_CALL" when any part of the response is a
       // function-call. That lets the finishReason → finishType mapping
       // classify it correctly as a tool_call.
-      const parts = candidate.content?.parts;
-      if (Array.isArray(parts) && parts.some((p: any) => p?.functionCall)) {
+      if (extractFunctionCalls(response).length > 0) {
         return GEMINI_FUNCTION_CALL_FINISH_REASON;
       }
       if (candidate.finishReason) {
@@ -86,13 +98,43 @@ function getMetadataUsage(response, _instance) {
   return null;
 }
 
+// Flattens any @google/genai content shape — string, Content ({ parts }),
+// Part ({ text }), or an array of those — into a single text string.
+function flattenContentText(value: any): string {
+  if (!value) return "";
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    return value.map(flattenContentText).filter((t) => t).join(" ");
+  }
+  if (value.parts && Array.isArray(value.parts)) {
+    return value.parts
+      .map((part: any) => (typeof part === "string" ? part : part?.text || ""))
+      .filter((text: string) => text)
+      .join(" ");
+  }
+  if (typeof value.text === "string") return value.text;
+  return "";
+}
+
 function extractMessages(args) {
   const params = args[0];
   const messages = [];
 
   if (params && typeof params === "object") {
+    // ADK (and direct genai callers) pass the agent/system prompt via
+    // config.systemInstruction rather than in contents, so capture it first.
+    const systemInstruction =
+      params.config?.systemInstruction ?? params.systemInstruction;
+    const systemText = flattenContentText(systemInstruction);
+    if (systemText) {
+      messages.push(JSON.stringify({ system: systemText }));
+    }
+  }
+
+  if (params && typeof params === "object") {
     if (typeof params.contents === "string") {
-      return [params.contents]
+      messages.push(params.contents);
+      return messages;
     } else if (Array.isArray(params.contents)) {
       for (const content of params.contents) {
         if (typeof content === "string") {
@@ -177,6 +219,16 @@ function extractInferenceOutput(result) {
 
       if (extractedText && extractedText.length > 0) {
         return extractedText;
+      }
+
+      // No text part — the output is a tool call / delegation. Serialize the
+      // functionCall(s) so the routing decision is captured, not an empty response.
+      const functionCalls = extractFunctionCalls(result?.response);
+      if (functionCalls.length > 0) {
+        const serialized = functionCalls.map((fc) => ({
+          function_call: { name: fc.name, args: fc.args },
+        }));
+        return JSON.stringify(serialized.length === 1 ? serialized[0] : serialized);
       }
     } else if (result?.error) {
       return result.error;

--- a/test/unit/gemini.test.ts
+++ b/test/unit/gemini.test.ts
@@ -156,3 +156,125 @@ describe('Gemini inference schema.subtype classifier', () => {
         expect(classify(null)).toBe('turn_end');
     });
 });
+
+// =============================================================================
+// data.input — system instruction + user message extraction
+// =============================================================================
+describe('Gemini inference data.input extraction', () => {
+    // Resolve the data.input "input" accessor from the schema and invoke it the
+    // way the instrumentation does: with { args }, where args is the call's
+    // argument list (args[0] === the genai params object).
+    const inputAccessor = (() => {
+        const event = (geminiInferenceConfig.events as any[]).find((e) => e.name === 'data.input');
+        const attr = event.attributes.find((a: any) => a.attribute === 'input');
+        return attr.accessor as (ctx: { args: any[] }) => string[];
+    })();
+
+    const extractInput = (params: any) => inputAccessor({ args: [params] });
+
+    it('captures a string systemInstruction ahead of the user message', () => {
+        const input = extractInput({
+            config: { systemInstruction: 'You are a travel agent.' },
+            contents: [{ role: 'user', parts: [{ text: 'book me a flight' }] }],
+        });
+        expect(input).toEqual([
+            JSON.stringify({ system: 'You are a travel agent.' }),
+            JSON.stringify({ user: 'book me a flight' }),
+        ]);
+    });
+
+    it('flattens a Content-shaped systemInstruction (parts)', () => {
+        const input = extractInput({
+            config: { systemInstruction: { role: 'system', parts: [{ text: 'Be concise.' }, { text: 'Be kind.' }] } },
+            contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+        });
+        expect(input[0]).toBe(JSON.stringify({ system: 'Be concise. Be kind.' }));
+    });
+
+    it('reads systemInstruction from the top-level param as a fallback', () => {
+        const input = extractInput({
+            systemInstruction: 'Top-level system prompt.',
+            contents: 'hello',
+        });
+        expect(input[0]).toBe(JSON.stringify({ system: 'Top-level system prompt.' }));
+    });
+
+    it('preserves the system message when contents is a bare string', () => {
+        const input = extractInput({
+            config: { systemInstruction: 'sys' },
+            contents: 'just a string',
+        });
+        expect(input).toEqual([JSON.stringify({ system: 'sys' }), 'just a string']);
+    });
+
+    it('omits the system entry when no systemInstruction is present', () => {
+        const input = extractInput({
+            contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+        });
+        expect(input).toEqual([JSON.stringify({ user: 'hi' })]);
+    });
+});
+
+// =============================================================================
+// data.output — text vs function-call response extraction
+// =============================================================================
+describe('Gemini inference data.output extraction', () => {
+    const responseAccessor = (() => {
+        const event = (geminiInferenceConfig.events as any[]).find((e) => e.name === 'data.output');
+        const attr = event.attributes.find((a: any) => a.attribute === 'response');
+        return attr.accessor as (ctx: any) => any;
+    })();
+
+    // status is derived from response.status; leaving it unset yields "success".
+    const extractOutput = (response: any) => responseAccessor({ response });
+
+    it('extracts plain text output', () => {
+        const out = extractOutput({
+            candidates: [{ finishReason: 'STOP', content: { parts: [{ text: 'Flight booked.' }] } }],
+        });
+        expect(out).toBe('Flight booked.');
+    });
+
+    it('serializes a single function-call response (was previously empty)', () => {
+        const out = extractOutput({
+            candidates: [{
+                finishReason: 'STOP',
+                content: { parts: [{ functionCall: { name: 'book_flight', args: { from: 'SFO', to: 'AYJ' } } }] },
+            }],
+        });
+        expect(JSON.parse(out)).toEqual({
+            function_call: { name: 'book_flight', args: { from: 'SFO', to: 'AYJ' } },
+        });
+    });
+
+    it('serializes multiple function calls as an array', () => {
+        const out = extractOutput({
+            candidates: [{
+                content: {
+                    parts: [
+                        { functionCall: { name: 'a', args: { x: 1 } } },
+                        { functionCall: { name: 'b', args: { y: 2 } } },
+                    ],
+                },
+            }],
+        });
+        expect(JSON.parse(out)).toEqual([
+            { function_call: { name: 'a', args: { x: 1 } } },
+            { function_call: { name: 'b', args: { y: 2 } } },
+        ]);
+    });
+
+    it('prefers text when a response interleaves text and a function call', () => {
+        const out = extractOutput({
+            candidates: [{
+                content: { parts: [{ text: 'Let me check.' }, { functionCall: { name: 'lookup' } }] },
+            }],
+        });
+        expect(out).toBe('Let me check.');
+    });
+
+    it('returns empty string when there is neither text nor a function call', () => {
+        const out = extractOutput({ candidates: [{ content: { parts: [] } }] });
+        expect(out).toBe('');
+    });
+});


### PR DESCRIPTION
## Summary

Fixes two gaps in Gemini inference span attributes, surfaced by the ADK travel-agent app where the model delegates to sub-agents and calls tools.

- **System input was dropped.** `extractMessages` only read `params.contents`, but ADK (and direct genai callers) pass the agent/system prompt via `config.systemInstruction`. We now read it and prepend a `{"system": ...}` entry to `data.input`.
- **Tool-call / delegation output was empty.** When the model returns a `functionCall` part (no text), `extractInferenceOutput` returned `""`. We now serialise the call as `{"function_call": {name, args}}` so the routing decision is captured.

## Changes

- New `extractFunctionCalls()` helper — single source of truth for tool-call detection; used by both finish-reason synthesis and output extraction (`extractFinishReason` refactored to use it).
- New `flattenContentText()` helper — normalizes any `@google/genai` content shape (string / `Content` / `Part` / array) into plain text.
- `extractMessages()` reads `config.systemInstruction`; fixed the string-`contents` branch so the system message isn't lost.
- `extractInferenceOutput()` falls back to serializing function calls when there's no text part.

## Effect on traces

Routing/tool-call inference spans (e.g. supervisor delegation, `adk_book_flight`) now show:
- a `{"system": ...}` entry alongside the user message in `data.input`
- a `data.output.response` with the `function_call` payload (previously empty)

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Test Cases:

<img width="936" height="635" alt="image" src="https://github.com/user-attachments/assets/f06c83ca-3fe1-4897-93ea-2ed6ab727e5d" />