### PR TITLE
Remove auto-generation of session IDs when not provided

### DIFF
--- a/src/instrumentation/metamodel/adk/adkProcessor.ts
+++ b/src/instrumentation/metamodel/adk/adkProcessor.ts
@@ -78,12 +78,15 @@ export class ADKRunnerSpanHandler extends DefaultSpanHandler {
         const params = callArgs?.[0] || {};
         const scopes: Record<string, string | null> = {};
 
-        // Session: prefer the runner's sessionId param. If missing (e.g.
-        // runEphemeral) and no session is already on the context, generate
-        // one. Don't overwrite an inherited session — multi-turn workflows
-        // need it stable across calls.
-        if (!getScopeFromContext(currentContext, SCOPE_AGENTIC_SESSION)) {
-            scopes[SCOPE_AGENTIC_SESSION] = params.sessionId ?? null;
+        // Session comes from the external app via the runner's sessionId
+        // param. Monocle only reads it — it never fabricates one. If the
+        // caller doesn't supply a sessionId (e.g. runEphemeral), leave the
+        // session scope unset rather than generating a synthetic id. Don't
+        // overwrite an inherited session — multi-turn workflows need it
+        // stable across calls.
+        if (!getScopeFromContext(currentContext, SCOPE_AGENTIC_SESSION)
+            && typeof params.sessionId === "string") {
+            scopes[SCOPE_AGENTIC_SESSION] = params.sessionId;
         }
         // Turn: one user message → one turn. ADK's runEphemeral internally
         // calls runAsync; both go through this handler and must share a


### PR DESCRIPTION
## Proposed changes

This PR removes the session info from trace, if not provided by external app, which was previously auto generated.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...