### PR TITLE
Refactor: remove unnecessary properties from ADK instrumentation

### DIFF
--- a/src/instrumentation/metamodel/adk/entities/inference.ts
+++ b/src/instrumentation/metamodel/adk/entities/inference.ts
@@ -38,13 +38,6 @@ function extractFinalResponseFromEvents(returnValue: any): string {
     return "";
 }
 
-function extractAgentToolNames(instance: any): string[] {
-    if (!Array.isArray(instance?.tools)) return [];
-    return instance.tools
-        .map((t: any) => t?.name || t?.agent?.name || "")
-        .filter((n: string) => n);
-}
-
 // Reads delegation info that ADKAgentSpanHandler.preTracing stamped on the
 // OTel context. Returns undefined for top-level invocations (no key set),
 // so the attribute is omitted — matching Python monocle's behavior.
@@ -88,14 +81,6 @@ export const AGENT = {
                 "attribute": "description",
                 "accessor": function ({ instance }: any) {
                     return instance?.description || "";
-                },
-            },
-            {
-                "_comment": "tools available to the agent",
-                "attribute": "tools",
-                "accessor": function ({ instance }: any) {
-                    const names = extractAgentToolNames(instance);
-                    return names.length > 0 ? names : undefined;
                 },
             },
             {
@@ -172,20 +157,6 @@ export const AGENT_REQUEST = {
                 "attribute": "type",
                 "accessor": function () {
                     return ADK_AGENT_TYPE;
-                },
-            },
-            {
-                "_comment": "root agent name as configured on the runner",
-                "attribute": "name",
-                "accessor": function ({ instance }: any) {
-                    return instance?.agent?.name || instance?.appName || "";
-                },
-            },
-            {
-                "_comment": "app name configured on the runner",
-                "attribute": "app_name",
-                "accessor": function ({ instance }: any) {
-                    return instance?.appName || "";
                 },
             },
         ],

--- a/src/instrumentation/metamodel/adk/entities/tools.ts
+++ b/src/instrumentation/metamodel/adk/entities/tools.ts
@@ -6,7 +6,7 @@ const ADK_AGENT_TYPE = "agent.adk";
 
 export const TOOL = {
     "type": SPAN_TYPES.AGENTIC_TOOL_INVOCATION,
-    "subtype": SPAN_SUBTYPES.ROUTING,
+    "subtype": SPAN_SUBTYPES.CONTENT_GENERATION,
     "attributes": [
         [
             {


### PR DESCRIPTION
## Proposed changes

This PR brings the following updates/fixes to ADK instrumentation:

- for tool invocation spans, span subtype shouldn't be ```routing``` but ```content_generation```
- remove the tools array from entity object of agentic invocation spans
- remove all extra properties except entity type from agentic turns entity.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...