### PR TITLE
Refactor: disable Monocle's global trace provider registration

### DIFF
--- a/src/instrumentation/common/instrumentation.ts
+++ b/src/instrumentation/common/instrumentation.ts
@@ -5,7 +5,7 @@ import {
     InstrumentationBase,
     InstrumentationNodeModuleDefinition,
 } from '@opentelemetry/instrumentation';
-import { context, trace } from "@opentelemetry/api";
+import { context } from "@opentelemetry/api";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { NodeTracerProvider, SpanProcessor } from "@opentelemetry/sdk-trace-node";
 import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
@@ -347,14 +347,6 @@ const setupMonocle = (
         setInstrumentor(monocleInstrumentation)
 
         monocleInstrumentation.setTracerProvider(tracerProvider);
-
-        // Attempt to register Monocle's tracer provider as the OTel global provider. If another provider is already registered, log a warning and skip registration to avoid conflicts.
-        const registered = trace.setGlobalTracerProvider(tracerProvider);
-        if (registered) {
-            consoleLog('Monocle registered as the global tracer provider');
-        } else {
-            consoleLog('Global tracer provider already set; Monocle skipping global registration');
-        }
 
         monocleInstrumentation.enable();
 


### PR DESCRIPTION
## Proposed changes

This PR resets the monocle registration as a global trace provider, which we did in PR #96 to read adk's internal spans, as we don't need them and its causing problems with other frameworks (like nextjs internal spans coming out), we're discarding that change.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...