### PR TITLE
Run Agent with monocle CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,82 @@ hooking them **at module load**, so Monocle must be set up **before your app imp
 those libraries**. One preload does this for both ESM and CommonJS; Next.js and
 `mastra dev` supply it their own way.
 
+### Run one file, without changing anything
+
+To trace a single script — an agent, a prototype, a reproduction — there is nothing to
+set up:
+
+```
+npx monocle2ai run src/agent.ts
+```
+
+Tracing is preloaded before your file loads, so the file needs no `setupMonocle()` call
+and your project keeps its `package.json`, lockfile and `node_modules` as they are. The
+file runs exactly as it would otherwise: arguments after the path are passed through,
+and stdin stays connected, so an agent that prompts for input still works.
+
+```
+npx monocle2ai run src/agent.ts --city Berlin
+```
+
+The target runs under [tsx](https://tsx.is), which handles TypeScript and both module
+systems. If tsx is not installed, Monocle fetches it with `npx` for the run only and
+tells you it did — nothing is added to your project.
+
+Name the workflow and choose where traces go with a `.env.monocle` file beside your
+`package.json`:
+
+```
+# .env.monocle
+MONOCLE_WORKFLOW_NAME=my-agent
+MONOCLE_EXPORTER=file
+```
+
+Monocle reads this file itself, so it applies however the app is started — including
+Next.js and `mastra dev`, which never see a `--env-file` flag. With no exporter set,
+traces are written as JSON under `.monocle/`. **Reading `.env.monocle` needs Node 20.12
+or 21.7+**; on older releases, set the variables in the environment instead.
+
+Use this to trace a run. To trace an application you start yourself — `npm start`, a
+dev server, anything with its own entry point — use the preload below instead.
+
+#### From VS Code
+
+The [Okahu AI Debugging Agent](https://marketplace.visualstudio.com/items?itemName=OkahuAI.okahu-ai-observability)
+extension for VS Code runs the same command for you, from either of two places:
+
+- **The sidebar.** Open the Okahu AI Observability view in the activity bar and pick
+  **Run Agent with Monocle2AI** under **TOOLS**.
+- **The editor.** Right-click the file and choose **Monocle → Run Agent with
+  Monocle2AI**.
+
+Both act on the file open in the editor and route on its language, so a TypeScript file
+runs through `monocle2ai run` — a terminal opens in the project and the file runs
+traced.
+
+**Instrument using Monocle2AI**, in the same two places, does the other half: it adds
+the preload to your `.env`, writes `.env.monocle`, and offers to add `--env-file` to
+whichever npm scripts you pick — for an app you start yourself rather than a file you
+run once.
+
 ### Node / tsx scripts (ESM and CommonJS)
 
-The same setup works for both module systems. Put the preload in `.env`:
+The same setup works for both module systems. Put the preload in `.env` — only the
+preload, since Node has to read it before startup and everything else belongs in
+`.env.monocle`:
 
 ```
 # .env
 NODE_OPTIONS=--import monocle2ai/register
-MONOCLE_WORKFLOW_NAME=my-app        # service name used by monocle2ai/register
+```
+
+```
+# .env.monocle — read by Monocle itself
+MONOCLE_WORKFLOW_NAME=my-app
 MONOCLE_EXPORTER=file
 ```
 
-and pass `--env-file` when you launch, so Node reads it **at startup**:
+and pass `--env-file` when you launch, so Node reads the preload **at startup**:
 
 ```jsonc
 // package.json
@@ -197,6 +261,11 @@ one-time warning telling you to externalize it. Silence or tune it with
 
 See [.env.example](.env.example) for all environment variables — exporters
 (console/file/S3/Azure/Okahu), output paths, preload, hook audit, and debug.
+
+Everything except `NODE_OPTIONS` belongs in `.env.monocle`, which Monocle reads for
+itself. Its values take precedence over the environment, so the same settings apply
+whichever way the app is started. `NODE_OPTIONS` is the exception: Node applies it
+before startup, so it has to be somewhere Node reads — your `.env`, or the shell.
 ## Roadmap 
 
 Goal of Monocle is to support tracing for apps written in *any language* with *any LLM orchestration or agentic framework* and built using models, vectors, agents or other components served up by *any cloud or model inference provider*. 

--- a/bin/cli
+++ b/bin/cli
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+// Thin shim: the package has no "type" field, so this file is CommonJS and can
+// require the CJS build directly. Copied verbatim into dist/bin/ by scripts/build.
+require("../cli.cjs").runCli();

--- a/scripts/utils/make-package-json-dist.cjs
+++ b/scripts/utils/make-package-json-dist.cjs
@@ -36,6 +36,8 @@ pkgJson.exports = {
   },
   './package.json': './package.json',
 };
+// `npx monocle2ai run <file>` — preloads tracing, then runs the target.
+pkgJson.bin = { monocle2ai: './bin/cli' };
 // delete pkgJson.scripts.prepack;
 // delete pkgJson.scripts.prepublishOnly;
 // delete pkgJson.scripts.prepare;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,139 @@
+import { spawn } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import { parseArgs, USAGE } from "./cli/args";
+import {
+    buildRunPlan,
+    isCompilerError,
+    isTypeScriptFile,
+    resolveRunnerCommand,
+    RunPlan,
+} from "./cli/runPlan";
+import { MONOCLE_VERSION } from "./instrumentation/common/monocle_version";
+
+const HELP = `monocle2ai — run a script with Monocle tracing enabled.
+
+${USAGE}
+
+  --tsx        Force the tsx runner instead of letting Node run the file.
+  --version    Print the Monocle version.
+  --help       Show this message.
+
+Tracing is preloaded before your code runs, so the target file needs no edits.
+Set MONOCLE_WORKFLOW_NAME to name the workflow (defaults to the package name).`;
+
+interface RunOutcome {
+    code: number;
+    stderr: string;
+    spawnFailed: boolean;
+}
+
+/**
+ * Run one attempt. stdin/stdout are inherited so the script stays interactive;
+ * stderr is echoed through but also captured, so a startup failure can be
+ * recognised without hiding it from the user.
+ */
+function runOnce(plan: RunPlan): Promise<RunOutcome> {
+    return new Promise((resolve) => {
+        const command = resolveRunnerCommand(plan.runner, plan.cwd);
+        if (command.bin === "npx") {
+            console.error(
+                "[monocle] tsx is not installed here; running it through npx. " +
+                "Your project is left untouched."
+            );
+        }
+        const child = spawn(command.bin, [...command.prefixArgs, ...plan.args], {
+            cwd: plan.cwd,
+            stdio: ["inherit", "inherit", "pipe"],
+            env: process.env,
+        });
+
+        let stderr = "";
+        child.stderr?.on("data", (chunk) => {
+            const text = chunk.toString();
+            stderr += text;
+            process.stderr.write(text);
+        });
+        child.on("error", (err) => {
+            resolve({ code: 1, stderr: `${stderr}${err.message}`, spawnFailed: true });
+        });
+        child.on("close", (code) => {
+            resolve({ code: code ?? 1, stderr, spawnFailed: false });
+        });
+    });
+}
+
+/**
+ * `monocle2ai run` is the only interface a user should need, so this points
+ * back at the same command rather than at the preload it uses internally.
+ */
+export function missingTsxMessage(file: string, detail = ""): string {
+    return (
+        `[monocle] ${path.basename(file)} needs the tsx runner to compile it, ` +
+        "and it could not be started.\n" +
+        (detail ? `          ${detail.trim()}\n` : "") +
+        "          Install it:  npm install -D tsx\n" +
+        `          Then re-run:  npx monocle2ai run ${file}`
+    );
+}
+
+function reportMissingTsx(file: string, detail = ""): void {
+    console.error(missingTsxMessage(file, detail));
+}
+
+export async function main(argv: string[]): Promise<number> {
+    const parsed = parseArgs(argv);
+
+    if (parsed.command === "help") {
+        console.log(HELP);
+        return 0;
+    }
+    if (parsed.command === "version") {
+        console.log(MONOCLE_VERSION);
+        return 0;
+    }
+    if (parsed.command === "error") {
+        console.error(parsed.message);
+        return 1;
+    }
+
+    const file = parsed.file as string;
+    if (!fs.existsSync(file)) {
+        console.error(`File not found: ${file}`);
+        return 1;
+    }
+
+    const plan = buildRunPlan(file, parsed.userArgs, { forceTsx: parsed.forceTsx });
+    const first = await runOnce(plan);
+    if (first.spawnFailed) {
+        reportMissingTsx(file, first.stderr);
+        return 1;
+    }
+    const canRetry =
+        first.code !== 0 &&
+        plan.runner === "node" &&
+        isTypeScriptFile(file) &&
+        isCompilerError(first.stderr);
+
+    if (!canRetry) {
+        return first.code;
+    }
+
+    // Node's type stripping cannot generate code or resolve tsconfig paths.
+    // Both failures happen at startup, before the script does any work, so
+    // re-running is safe.
+    console.error(
+        "\n[monocle] Node could not run this TypeScript file directly. Retrying with tsx..."
+    );
+    const retryPlan = buildRunPlan(file, parsed.userArgs, { forceTsx: true });
+    const second = await runOnce(retryPlan);
+    if (second.spawnFailed) {
+        reportMissingTsx(file, second.stderr);
+        return first.code;
+    }
+    return second.code;
+}
+
+export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
+    process.exitCode = await main(argv);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ ${USAGE}
 Tracing is preloaded before your code runs, so the target file needs no edits.
 Set MONOCLE_WORKFLOW_NAME to name the workflow (defaults to the package name).`;
 
-interface RunOutcome {
+export interface RunOutcome {
     code: number;
     /** Set when the runner itself could not be started, as opposed to failing. */
     spawnError?: string;
@@ -24,21 +24,34 @@ interface RunOutcome {
 /**
  * Run the target. All three streams are inherited so the script stays fully
  * interactive and its output is never buffered or reordered.
+ *
+ * Node emits only EACCES, EAGAIN, EMFILE, ENFILE and ENOENT as 'error' events
+ * and throws every other spawn failure, so the call is guarded: an unguarded
+ * throw escapes this executor and reaches the user as a raw Node stack.
  */
-function runOnce(plan: RunPlan): Promise<RunOutcome> {
+export function runOnce(
+    plan: RunPlan,
+    execPath: string = process.execPath
+): Promise<RunOutcome> {
     return new Promise((resolve) => {
-        const command = resolveRunnerCommand(plan.cwd);
-        if (command.bin === "npx") {
+        const command = resolveRunnerCommand(plan.cwd, execPath);
+        if (command.usedNpx) {
             console.error(
                 "[monocle] tsx is not installed here; running it through npx. " +
                 "Your project is left untouched."
             );
         }
-        const child = spawn(command.bin, [...command.prefixArgs, ...plan.args], {
-            cwd: plan.cwd,
-            stdio: "inherit",
-            env: process.env,
-        });
+        let child;
+        try {
+            child = spawn(command.bin, [...command.prefixArgs, ...plan.args], {
+                cwd: plan.cwd,
+                stdio: "inherit",
+                env: process.env,
+            });
+        } catch (err) {
+            resolve({ code: 1, spawnError: (err as Error).message });
+            return;
+        }
 
         child.on("error", (err) => resolve({ code: 1, spawnError: err.message }));
         child.on("close", (code) => resolve({ code: code ?? 1 }));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,20 +2,13 @@ import { spawn } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import { parseArgs, USAGE } from "./cli/args";
-import {
-    buildRunPlan,
-    isCompilerError,
-    isTypeScriptFile,
-    resolveRunnerCommand,
-    RunPlan,
-} from "./cli/runPlan";
+import { buildRunPlan, resolveRunnerCommand, RunPlan } from "./cli/runPlan";
 import { MONOCLE_VERSION } from "./instrumentation/common/monocle_version";
 
 const HELP = `monocle2ai — run a script with Monocle tracing enabled.
 
 ${USAGE}
 
-  --tsx        Force the tsx runner instead of letting Node run the file.
   --version    Print the Monocle version.
   --help       Show this message.
 
@@ -24,18 +17,17 @@ Set MONOCLE_WORKFLOW_NAME to name the workflow (defaults to the package name).`;
 
 interface RunOutcome {
     code: number;
-    stderr: string;
-    spawnFailed: boolean;
+    /** Set when the runner itself could not be started, as opposed to failing. */
+    spawnError?: string;
 }
 
 /**
- * Run one attempt. stdin/stdout are inherited so the script stays interactive;
- * stderr is echoed through but also captured, so a startup failure can be
- * recognised without hiding it from the user.
+ * Run the target. All three streams are inherited so the script stays fully
+ * interactive and its output is never buffered or reordered.
  */
 function runOnce(plan: RunPlan): Promise<RunOutcome> {
     return new Promise((resolve) => {
-        const command = resolveRunnerCommand(plan.runner, plan.cwd);
+        const command = resolveRunnerCommand(plan.cwd);
         if (command.bin === "npx") {
             console.error(
                 "[monocle] tsx is not installed here; running it through npx. " +
@@ -44,22 +36,12 @@ function runOnce(plan: RunPlan): Promise<RunOutcome> {
         }
         const child = spawn(command.bin, [...command.prefixArgs, ...plan.args], {
             cwd: plan.cwd,
-            stdio: ["inherit", "inherit", "pipe"],
+            stdio: "inherit",
             env: process.env,
         });
 
-        let stderr = "";
-        child.stderr?.on("data", (chunk) => {
-            const text = chunk.toString();
-            stderr += text;
-            process.stderr.write(text);
-        });
-        child.on("error", (err) => {
-            resolve({ code: 1, stderr: `${stderr}${err.message}`, spawnFailed: true });
-        });
-        child.on("close", (code) => {
-            resolve({ code: code ?? 1, stderr, spawnFailed: false });
-        });
+        child.on("error", (err) => resolve({ code: 1, spawnError: err.message }));
+        child.on("close", (code) => resolve({ code: code ?? 1 }));
     });
 }
 
@@ -69,16 +51,12 @@ function runOnce(plan: RunPlan): Promise<RunOutcome> {
  */
 export function missingTsxMessage(file: string, detail = ""): string {
     return (
-        `[monocle] ${path.basename(file)} needs the tsx runner to compile it, ` +
+        `[monocle] ${path.basename(file)} needs the tsx runner, ` +
         "and it could not be started.\n" +
         (detail ? `          ${detail.trim()}\n` : "") +
         "          Install it:  npm install -D tsx\n" +
         `          Then re-run:  npx monocle2ai run ${file}`
     );
-}
-
-function reportMissingTsx(file: string, detail = ""): void {
-    console.error(missingTsxMessage(file, detail));
 }
 
 export async function main(argv: string[]): Promise<number> {
@@ -103,35 +81,11 @@ export async function main(argv: string[]): Promise<number> {
         return 1;
     }
 
-    const plan = buildRunPlan(file, parsed.userArgs, { forceTsx: parsed.forceTsx });
-    const first = await runOnce(plan);
-    if (first.spawnFailed) {
-        reportMissingTsx(file, first.stderr);
-        return 1;
+    const outcome = await runOnce(buildRunPlan(file, parsed.userArgs));
+    if (outcome.spawnError) {
+        console.error(missingTsxMessage(file, outcome.spawnError));
     }
-    const canRetry =
-        first.code !== 0 &&
-        plan.runner === "node" &&
-        isTypeScriptFile(file) &&
-        isCompilerError(first.stderr);
-
-    if (!canRetry) {
-        return first.code;
-    }
-
-    // Node's type stripping cannot generate code or resolve tsconfig paths.
-    // Both failures happen at startup, before the script does any work, so
-    // re-running is safe.
-    console.error(
-        "\n[monocle] Node could not run this TypeScript file directly. Retrying with tsx..."
-    );
-    const retryPlan = buildRunPlan(file, parsed.userArgs, { forceTsx: true });
-    const second = await runOnce(retryPlan);
-    if (second.spawnFailed) {
-        reportMissingTsx(file, second.stderr);
-        return first.code;
-    }
-    return second.code;
+    return outcome.code;
 }
 
 export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -6,21 +6,18 @@ export interface ParsedArgs {
     file?: string;
     /** Everything after the target — passed through untouched. */
     userArgs: string[];
-    /** `--tsx` given before the target. */
-    forceTsx: boolean;
     /** Explanation, when command is "error". */
     message?: string;
 }
 
-const USAGE = "Usage: monocle2ai run [--tsx] <file> [args...]";
+const USAGE = "Usage: monocle2ai run <file> [args...]";
 
 /**
- * Parse CLI arguments. Only flags before the target file belong to Monocle;
- * everything after it is passed to the script, so a target with its own
- * `--tsx` flag still works.
+ * Parse CLI arguments. Everything after the target file is passed to the
+ * script untouched, so a target with flags of its own still works.
  */
 export function parseArgs(argv: string[]): ParsedArgs {
-    const empty = { userArgs: [] as string[], forceTsx: false };
+    const empty = { userArgs: [] as string[] };
 
     if (argv.length === 0) {
         return { command: "help", ...empty };
@@ -42,29 +39,12 @@ export function parseArgs(argv: string[]): ParsedArgs {
         };
     }
 
-    let forceTsx = false;
-    let index = 0;
-    while (index < rest.length && rest[index] === "--tsx") {
-        forceTsx = true;
-        index++;
-    }
-
-    const file = rest[index];
+    const [file, ...userArgs] = rest;
     if (!file) {
-        return {
-            command: "error",
-            message: `No file given. ${USAGE}`,
-            userArgs: [],
-            forceTsx,
-        };
+        return { command: "error", message: `No file given. ${USAGE}`, userArgs: [] };
     }
 
-    return {
-        command: "run",
-        file,
-        userArgs: rest.slice(index + 1),
-        forceTsx,
-    };
+    return { command: "run", file, userArgs };
 }
 
 export { USAGE };

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,70 @@
+export type Command = "run" | "help" | "version" | "error";
+
+export interface ParsedArgs {
+    command: Command;
+    /** Target script, for `run`. */
+    file?: string;
+    /** Everything after the target — passed through untouched. */
+    userArgs: string[];
+    /** `--tsx` given before the target. */
+    forceTsx: boolean;
+    /** Explanation, when command is "error". */
+    message?: string;
+}
+
+const USAGE = "Usage: monocle2ai run [--tsx] <file> [args...]";
+
+/**
+ * Parse CLI arguments. Only flags before the target file belong to Monocle;
+ * everything after it is passed to the script, so a target with its own
+ * `--tsx` flag still works.
+ */
+export function parseArgs(argv: string[]): ParsedArgs {
+    const empty = { userArgs: [] as string[], forceTsx: false };
+
+    if (argv.length === 0) {
+        return { command: "help", ...empty };
+    }
+
+    const [head, ...rest] = argv;
+
+    if (head === "--help" || head === "-h" || head === "help") {
+        return { command: "help", ...empty };
+    }
+    if (head === "--version" || head === "-v") {
+        return { command: "version", ...empty };
+    }
+    if (head !== "run") {
+        return {
+            command: "error",
+            message: `Unknown command "${head}". ${USAGE}`,
+            ...empty,
+        };
+    }
+
+    let forceTsx = false;
+    let index = 0;
+    while (index < rest.length && rest[index] === "--tsx") {
+        forceTsx = true;
+        index++;
+    }
+
+    const file = rest[index];
+    if (!file) {
+        return {
+            command: "error",
+            message: `No file given. ${USAGE}`,
+            userArgs: [],
+            forceTsx,
+        };
+    }
+
+    return {
+        command: "run",
+        file,
+        userArgs: rest.slice(index + 1),
+        forceTsx,
+    };
+}
+
+export { USAGE };

--- a/src/cli/runPlan.ts
+++ b/src/cli/runPlan.ts
@@ -40,17 +40,17 @@ export function projectDirFor(filePath: string): string {
 }
 
 /**
- * Locate an executable installed by npm, walking up from `startDir` the way
- * module resolution does — package managers hoist binaries to the workspace
- * root, so a nested package's own directory often will not hold them.
+ * Locate tsx's own JS entry point, walking up from `startDir` the way module
+ * resolution does — package managers hoist dependencies to the workspace root.
+ * We resolve the package rather than node_modules/.bin deliberately: those are
+ * shell shims, and Windows ships tsx.cmd, which Node refuses to spawn.
  */
-export function findLocalBin(name: string, startDir: string): string | undefined {
-    const binName = process.platform === "win32" ? `${name}.cmd` : name;
+export function findTsxEntry(startDir: string): string | undefined {
     let dir = path.resolve(startDir);
     for (;;) {
-        const candidate = path.join(dir, "node_modules", ".bin", binName);
-        if (fs.existsSync(candidate)) {
-            return candidate;
+        const entry = binEntryOf(path.join(dir, "node_modules", "tsx"));
+        if (entry) {
+            return entry;
         }
         const parent = path.dirname(dir);
         if (parent === dir) {
@@ -60,23 +60,75 @@ export function findLocalBin(name: string, startDir: string): string | undefined
     }
 }
 
-export interface RunnerCommand {
-    /** Executable to spawn. */
-    bin: string;
-    /** Arguments that must precede the run arguments (used by the npx fallback). */
-    prefixArgs: string[];
+/** Resolve a package's `bin` field to an existing file, in either declared form. */
+function binEntryOf(pkgDir: string): string | undefined {
+    let bin: unknown;
+    try {
+        bin = JSON.parse(
+            fs.readFileSync(path.join(pkgDir, "package.json"), "utf8")
+        ).bin;
+    } catch {
+        return undefined;
+    }
+    const rel =
+        typeof bin === "string"
+            ? bin
+            : bin && typeof bin === "object"
+              ? Object.values(bin as Record<string, string>)[0]
+              : undefined;
+    if (typeof rel !== "string") {
+        return undefined;
+    }
+    const entry = path.join(pkgDir, rel);
+    return fs.existsSync(entry) ? entry : undefined;
 }
 
 /**
- * Resolve how to invoke tsx. When it is not installed we fall back to
- * `npx --yes tsx` rather than refusing: npx serves it from a user-level cache
- * and leaves package.json, the lockfile and node_modules untouched.
+ * Find the npx script npm ships, so the fallback can run through node too.
+ * Windows keeps npm beside the binary and POSIX keeps it under ../lib, and
+ * every mainstream installer and version manager uses one of the two.
  */
-export function resolveRunnerCommand(cwd: string): RunnerCommand {
-    const local = findLocalBin("tsx", cwd);
-    return local
-        ? { bin: local, prefixArgs: [] }
-        : { bin: "npx", prefixArgs: ["--yes", "tsx"] };
+export function findNpxCli(execPath: string = process.execPath): string | undefined {
+    const dir = path.dirname(execPath);
+    return [
+        path.join(dir, "node_modules", "npm", "bin", "npx-cli.js"),
+        path.join(dir, "..", "lib", "node_modules", "npm", "bin", "npx-cli.js"),
+    ].find((candidate) => fs.existsSync(candidate));
+}
+
+export interface RunnerCommand {
+    /** Executable to spawn. */
+    bin: string;
+    /** Arguments that must precede the run arguments. */
+    prefixArgs: string[];
+    /** Whether tsx is being fetched on the fly rather than run from the project. */
+    usedNpx: boolean;
+}
+
+/**
+ * Resolve how to invoke tsx, through the running node binary so that no shell
+ * shim is spawned: Node returns EINVAL rather than executing a .cmd or .bat
+ * without a shell, which is how this failed on Windows. The result no longer
+ * varies by platform.
+ *
+ * When tsx is not installed we fetch it with npx rather than refusing — that
+ * serves it from a user-level cache and leaves package.json, the lockfile and
+ * node_modules untouched. Bare "npx" is the last resort, for the rare layout
+ * where npm is not beside node; it works on POSIX, and on Windows the CLI
+ * turns the resulting failure into install guidance.
+ */
+export function resolveRunnerCommand(
+    cwd: string,
+    execPath: string = process.execPath
+): RunnerCommand {
+    const tsx = findTsxEntry(cwd);
+    if (tsx) {
+        return { bin: execPath, prefixArgs: [tsx], usedNpx: false };
+    }
+    const npxCli = findNpxCli(execPath);
+    return npxCli
+        ? { bin: execPath, prefixArgs: [npxCli, "--yes", "tsx"], usedNpx: true }
+        : { bin: "npx", prefixArgs: ["--yes", "tsx"], usedNpx: true };
 }
 
 /**

--- a/src/cli/runPlan.ts
+++ b/src/cli/runPlan.ts
@@ -2,77 +2,25 @@ import * as fs from "fs";
 import * as path from "path";
 
 export type PreloadFlag = "--import" | "--require";
-export type Runner = "node" | "tsx";
 
 export interface RunPlan {
-    /** Executable to spawn. */
-    runner: Runner;
     /** Full argument list, preload flag first and user args last. */
     args: string[];
     /** Directory to run from — tsconfig discovery and module resolution depend on it. */
     cwd: string;
 }
 
-export interface RunPlanOptions {
-    /** Skip the heuristics and use tsx regardless. */
-    forceTsx?: boolean;
-}
-
-const TYPESCRIPT_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts"];
-// Extensions Node always loads through the CommonJS require hook. A .cts entry
-// additionally breaks inside import-in-the-middle when loaded via --import.
-const COMMONJS_EXTENSIONS = [".cts", ".cjs"];
-// Extensions that always mean ESM, whatever the file contains.
-const ESM_EXTENSIONS = [".mts", ".mjs"];
-
-// TypeScript that Node's strip-only mode cannot run, because each needs code to
-// be generated rather than erased.
-const NEEDS_COMPILER = [
-    /^\s*(?:export\s+)?(?:declare\s+)?(?:const\s+)?enum\s+\w/m,
-    /^\s*(?:export\s+)?(?:declare\s+)?namespace\s+\w/m,
-    /^\s*@\w+/m,
-    /constructor\s*\([^)]*\b(?:private|public|protected|readonly)\b/,
-];
-
-// Startup failures that mean "this needs a real TypeScript compiler":
-// unsupported syntax, or a path alias Node cannot resolve.
-const COMPILER_ERROR_CODES = [
-    "ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX",
-    "ERR_MODULE_NOT_FOUND",
-    // ESM syntax reaching a CommonJS loader. Turning `export` into
-    // `exports.x` is a transform, which Node's strip-only mode will not do.
-    "Unexpected token 'export'",
-    "Cannot use import statement outside a module",
-];
-
-export function isTypeScriptFile(filePath: string): boolean {
-    return TYPESCRIPT_EXTENSIONS.includes(path.extname(filePath).toLowerCase());
-}
+// The one target import-in-the-middle cannot take through --import: it throws
+// "is not in cache". Every other extension loads correctly that way under tsx.
+const REQUIRE_PRELOAD_EXTENSIONS = [".cts"];
 
 /**
- * Which preload flag to use. `--import` routes the entry through the ESM loader,
- * where a CommonJS module hits import-in-the-middle's sync-require path and dies
- * with "is not in cache". A pinning extension wins; otherwise syntax decides.
+ * Which preload flag to use. tsx compiles the target either way, so the file's
+ * own module system no longer matters — only .cts needs --require.
  */
-export function preloadFlagFor(filePath: string, fileText = ""): PreloadFlag {
+export function preloadFlagFor(filePath: string): PreloadFlag {
     const ext = path.extname(filePath).toLowerCase();
-    if (COMMONJS_EXTENSIONS.includes(ext)) {
-        return "--require";
-    }
-    if (ESM_EXTENSIONS.includes(ext)) {
-        return "--import";
-    }
-    // Unknown contents default to --import: most agent files are ESM, and that
-    // is the path with working TypeScript support.
-    return !fileText || usesEsmSyntax(fileText) ? "--import" : "--require";
-}
-
-export function needsTypeScriptCompiler(fileText: string): boolean {
-    return NEEDS_COMPILER.some((pattern) => pattern.test(fileText));
-}
-
-export function isCompilerError(output: string): boolean {
-    return COMPILER_ERROR_CODES.some((code) => output.includes(code));
+    return REQUIRE_PRELOAD_EXTENSIONS.includes(ext) ? "--require" : "--import";
 }
 
 /** Directory of the nearest package.json, or the file's own directory. */
@@ -86,33 +34,6 @@ export function projectDirFor(filePath: string): string {
         const parent = path.dirname(dir);
         if (parent === dir) {
             return fileDir;
-        }
-        dir = parent;
-    }
-}
-
-/**
- * Whether the nearest tsconfig declares path aliases. Node never reads
- * tsconfig, so an aliased import fails there and needs tsx.
- */
-export function tsconfigHasPaths(startDir: string): boolean {
-    let dir = path.resolve(startDir);
-    for (;;) {
-        const candidate = path.join(dir, "tsconfig.json");
-        if (fs.existsSync(candidate)) {
-            const text = readOrEmpty(candidate);
-            try {
-                const config = JSON.parse(text);
-                return Object.keys(config?.compilerOptions?.paths ?? {}).length > 0;
-            } catch {
-                // tsconfig files routinely carry comments, which JSON.parse
-                // rejects. Fall back to looking for the key itself.
-                return /"paths"\s*:/.test(text);
-            }
-        }
-        const parent = path.dirname(dir);
-        if (parent === dir) {
-            return false;
         }
         dir = parent;
     }
@@ -139,128 +60,6 @@ export function findLocalBin(name: string, startDir: string): string | undefined
     }
 }
 
-function readOrEmpty(filePath: string): string {
-    try {
-        return fs.readFileSync(filePath, "utf8");
-    } catch {
-        return "";
-    }
-}
-
-/** Parsed compilerOptions of the nearest tsconfig, as far as we can read it. */
-function nearestCompilerOptions(startDir: string): Record<string, unknown> | undefined {
-    let dir = path.resolve(startDir);
-    for (;;) {
-        const candidate = path.join(dir, "tsconfig.json");
-        if (fs.existsSync(candidate)) {
-            try {
-                return JSON.parse(readOrEmpty(candidate))?.compilerOptions ?? {};
-            } catch {
-                return undefined;
-            }
-        }
-        const parent = path.dirname(dir);
-        if (parent === dir) {
-            return undefined;
-        }
-        dir = parent;
-    }
-}
-
-/**
- * Whether the project relies on bundler-style module resolution, which permits
- * extensionless relative imports. Node's ESM loader demands extensions, so
- * these projects cannot run on plain node.
- */
-export function tsconfigNeedsBundler(startDir: string): boolean {
-    const options = nearestCompilerOptions(startDir);
-    const resolution = options?.moduleResolution;
-    return typeof resolution === "string" && resolution.toLowerCase() === "bundler";
-}
-
-
-// A top-level `import` or `export` statement, as opposed to a dynamic
-// `import(...)` call or the words appearing inside a string.
-const ESM_SYNTAX = /^[ \t]*(?:export\s+(?:default\s+)?[{*a-zA-Z_$]|import\s*[{*'"._$a-zA-Z])/m;
-
-export function usesEsmSyntax(fileText: string): boolean {
-    return ESM_SYNTAX.test(fileText);
-}
-
-// Comments and string literals, so a file that merely talks about require()
-// is not mistaken for one that calls it.
-const COMMENT_OR_STRING =
-    /\/\*[\s\S]*?\*\/|\/\/[^\n]*|'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|`(?:\\.|[^`\\])*`/g;
-
-// A require() call. Excludes a preceding word character or dot, so neither
-// `requireAuth` nor `foo.require(...)` counts.
-const REQUIRE_CALL = /(?:^|[^.\w$])require\s*\(/;
-
-/** Whether a file calls require(), which does not exist in ES module scope. */
-export function usesRequire(fileText: string): boolean {
-    return REQUIRE_CALL.test(fileText.replace(COMMENT_OR_STRING, " "));
-}
-
-/** The `type` field of the nearest package.json, if it sets one. */
-export function packageTypeFor(startDir: string): string | undefined {
-    let dir = path.resolve(startDir);
-    for (;;) {
-        const candidate = path.join(dir, "package.json");
-        if (fs.existsSync(candidate)) {
-            try {
-                return JSON.parse(readOrEmpty(candidate))?.type;
-            } catch {
-                return undefined;
-            }
-        }
-        const parent = path.dirname(dir);
-        if (parent === dir) {
-            return undefined;
-        }
-        dir = parent;
-    }
-}
-
-function chooseRunner(
-    filePath: string,
-    cwd: string,
-    options: RunPlanOptions
-): Runner {
-    if (options.forceTsx) {
-        return "tsx";
-    }
-    // Plain JavaScript never needs a compiler, whatever the project config.
-    if (!isTypeScriptFile(filePath)) {
-        return "node";
-    }
-    const text = readOrEmpty(filePath);
-    if (needsTypeScriptCompiler(text)) {
-        return "tsx";
-    }
-    // A package that declares "commonjs" (or a .cts file) never gets Node's
-    // detect-and-reparse rescue, so ESM syntax there is a hard failure.
-    const ext = path.extname(filePath).toLowerCase();
-    const packageType = packageTypeFor(cwd);
-    const alwaysCommonJs = ext === ".cts" || packageType === "commonjs";
-    if (alwaysCommonJs && usesEsmSyntax(text)) {
-        return "tsx";
-    }
-    // The mirror image: `require` does not exist in ESM scope. Node loads the
-    // file as ESM when the extension or package says so, and also when it
-    // reparses a typeless file after spotting module syntax. tsx handles both.
-    const loadedAsEsm =
-        ext === ".mts" ||
-        packageType === "module" ||
-        (!alwaysCommonJs && usesEsmSyntax(text));
-    if (loadedAsEsm && usesRequire(text)) {
-        return "tsx";
-    }
-    if (tsconfigHasPaths(cwd) || tsconfigNeedsBundler(cwd)) {
-        return "tsx";
-    }
-    return "node";
-}
-
 export interface RunnerCommand {
     /** Executable to spawn. */
     bin: string;
@@ -269,14 +68,11 @@ export interface RunnerCommand {
 }
 
 /**
- * Resolve how to invoke a runner. When tsx is not installed we fall back to
+ * Resolve how to invoke tsx. When it is not installed we fall back to
  * `npx --yes tsx` rather than refusing: npx serves it from a user-level cache
  * and leaves package.json, the lockfile and node_modules untouched.
  */
-export function resolveRunnerCommand(runner: Runner, cwd: string): RunnerCommand {
-    if (runner === "node") {
-        return { bin: process.execPath, prefixArgs: [] };
-    }
+export function resolveRunnerCommand(cwd: string): RunnerCommand {
     const local = findLocalBin("tsx", cwd);
     return local
         ? { bin: local, prefixArgs: [] }
@@ -284,27 +80,19 @@ export function resolveRunnerCommand(runner: Runner, cwd: string): RunnerCommand
 }
 
 /**
- * Decide how to run `filePath` with Monocle tracing preloaded.
- *
- * Node runs most TypeScript directly by stripping types, so it is the default;
- * tsx is used only where Node provably cannot cope.
+ * Decide how to run `filePath` with Monocle tracing preloaded. Everything goes
+ * through tsx: it handles every module system and TypeScript feature Node's
+ * strip-only mode cannot, for ~170ms against a multi-second tracing startup.
  */
-export function buildRunPlan(
-    filePath: string,
-    userArgs: string[],
-    options: RunPlanOptions = {}
-): RunPlan {
+export function buildRunPlan(filePath: string, userArgs: string[]): RunPlan {
     const resolved = path.resolve(filePath);
-    const cwd = projectDirFor(resolved);
-    const text = readOrEmpty(resolved);
     return {
-        runner: chooseRunner(resolved, cwd, options),
         args: [
-            preloadFlagFor(resolved, text),
+            preloadFlagFor(resolved),
             "monocle2ai/register",
             resolved,
             ...userArgs,
         ],
-        cwd,
+        cwd: projectDirFor(resolved),
     };
 }

--- a/src/cli/runPlan.ts
+++ b/src/cli/runPlan.ts
@@ -1,0 +1,310 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export type PreloadFlag = "--import" | "--require";
+export type Runner = "node" | "tsx";
+
+export interface RunPlan {
+    /** Executable to spawn. */
+    runner: Runner;
+    /** Full argument list, preload flag first and user args last. */
+    args: string[];
+    /** Directory to run from — tsconfig discovery and module resolution depend on it. */
+    cwd: string;
+}
+
+export interface RunPlanOptions {
+    /** Skip the heuristics and use tsx regardless. */
+    forceTsx?: boolean;
+}
+
+const TYPESCRIPT_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts"];
+// Extensions Node always loads through the CommonJS require hook. A .cts entry
+// additionally breaks inside import-in-the-middle when loaded via --import.
+const COMMONJS_EXTENSIONS = [".cts", ".cjs"];
+// Extensions that always mean ESM, whatever the file contains.
+const ESM_EXTENSIONS = [".mts", ".mjs"];
+
+// TypeScript that Node's strip-only mode cannot run, because each needs code to
+// be generated rather than erased.
+const NEEDS_COMPILER = [
+    /^\s*(?:export\s+)?(?:declare\s+)?(?:const\s+)?enum\s+\w/m,
+    /^\s*(?:export\s+)?(?:declare\s+)?namespace\s+\w/m,
+    /^\s*@\w+/m,
+    /constructor\s*\([^)]*\b(?:private|public|protected|readonly)\b/,
+];
+
+// Startup failures that mean "this needs a real TypeScript compiler":
+// unsupported syntax, or a path alias Node cannot resolve.
+const COMPILER_ERROR_CODES = [
+    "ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX",
+    "ERR_MODULE_NOT_FOUND",
+    // ESM syntax reaching a CommonJS loader. Turning `export` into
+    // `exports.x` is a transform, which Node's strip-only mode will not do.
+    "Unexpected token 'export'",
+    "Cannot use import statement outside a module",
+];
+
+export function isTypeScriptFile(filePath: string): boolean {
+    return TYPESCRIPT_EXTENSIONS.includes(path.extname(filePath).toLowerCase());
+}
+
+/**
+ * Which preload flag to use. `--import` routes the entry through the ESM loader,
+ * where a CommonJS module hits import-in-the-middle's sync-require path and dies
+ * with "is not in cache". A pinning extension wins; otherwise syntax decides.
+ */
+export function preloadFlagFor(filePath: string, fileText = ""): PreloadFlag {
+    const ext = path.extname(filePath).toLowerCase();
+    if (COMMONJS_EXTENSIONS.includes(ext)) {
+        return "--require";
+    }
+    if (ESM_EXTENSIONS.includes(ext)) {
+        return "--import";
+    }
+    // Unknown contents default to --import: most agent files are ESM, and that
+    // is the path with working TypeScript support.
+    return !fileText || usesEsmSyntax(fileText) ? "--import" : "--require";
+}
+
+export function needsTypeScriptCompiler(fileText: string): boolean {
+    return NEEDS_COMPILER.some((pattern) => pattern.test(fileText));
+}
+
+export function isCompilerError(output: string): boolean {
+    return COMPILER_ERROR_CODES.some((code) => output.includes(code));
+}
+
+/** Directory of the nearest package.json, or the file's own directory. */
+export function projectDirFor(filePath: string): string {
+    const fileDir = path.dirname(path.resolve(filePath));
+    let dir = fileDir;
+    for (;;) {
+        if (fs.existsSync(path.join(dir, "package.json"))) {
+            return dir;
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            return fileDir;
+        }
+        dir = parent;
+    }
+}
+
+/**
+ * Whether the nearest tsconfig declares path aliases. Node never reads
+ * tsconfig, so an aliased import fails there and needs tsx.
+ */
+export function tsconfigHasPaths(startDir: string): boolean {
+    let dir = path.resolve(startDir);
+    for (;;) {
+        const candidate = path.join(dir, "tsconfig.json");
+        if (fs.existsSync(candidate)) {
+            const text = readOrEmpty(candidate);
+            try {
+                const config = JSON.parse(text);
+                return Object.keys(config?.compilerOptions?.paths ?? {}).length > 0;
+            } catch {
+                // tsconfig files routinely carry comments, which JSON.parse
+                // rejects. Fall back to looking for the key itself.
+                return /"paths"\s*:/.test(text);
+            }
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            return false;
+        }
+        dir = parent;
+    }
+}
+
+/**
+ * Locate an executable installed by npm, walking up from `startDir` the way
+ * module resolution does — package managers hoist binaries to the workspace
+ * root, so a nested package's own directory often will not hold them.
+ */
+export function findLocalBin(name: string, startDir: string): string | undefined {
+    const binName = process.platform === "win32" ? `${name}.cmd` : name;
+    let dir = path.resolve(startDir);
+    for (;;) {
+        const candidate = path.join(dir, "node_modules", ".bin", binName);
+        if (fs.existsSync(candidate)) {
+            return candidate;
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            return undefined;
+        }
+        dir = parent;
+    }
+}
+
+function readOrEmpty(filePath: string): string {
+    try {
+        return fs.readFileSync(filePath, "utf8");
+    } catch {
+        return "";
+    }
+}
+
+/** Parsed compilerOptions of the nearest tsconfig, as far as we can read it. */
+function nearestCompilerOptions(startDir: string): Record<string, unknown> | undefined {
+    let dir = path.resolve(startDir);
+    for (;;) {
+        const candidate = path.join(dir, "tsconfig.json");
+        if (fs.existsSync(candidate)) {
+            try {
+                return JSON.parse(readOrEmpty(candidate))?.compilerOptions ?? {};
+            } catch {
+                return undefined;
+            }
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            return undefined;
+        }
+        dir = parent;
+    }
+}
+
+/**
+ * Whether the project relies on bundler-style module resolution, which permits
+ * extensionless relative imports. Node's ESM loader demands extensions, so
+ * these projects cannot run on plain node.
+ */
+export function tsconfigNeedsBundler(startDir: string): boolean {
+    const options = nearestCompilerOptions(startDir);
+    const resolution = options?.moduleResolution;
+    return typeof resolution === "string" && resolution.toLowerCase() === "bundler";
+}
+
+
+// A top-level `import` or `export` statement, as opposed to a dynamic
+// `import(...)` call or the words appearing inside a string.
+const ESM_SYNTAX = /^[ \t]*(?:export\s+(?:default\s+)?[{*a-zA-Z_$]|import\s*[{*'"._$a-zA-Z])/m;
+
+export function usesEsmSyntax(fileText: string): boolean {
+    return ESM_SYNTAX.test(fileText);
+}
+
+// Comments and string literals, so a file that merely talks about require()
+// is not mistaken for one that calls it.
+const COMMENT_OR_STRING =
+    /\/\*[\s\S]*?\*\/|\/\/[^\n]*|'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|`(?:\\.|[^`\\])*`/g;
+
+// A require() call. Excludes a preceding word character or dot, so neither
+// `requireAuth` nor `foo.require(...)` counts.
+const REQUIRE_CALL = /(?:^|[^.\w$])require\s*\(/;
+
+/** Whether a file calls require(), which does not exist in ES module scope. */
+export function usesRequire(fileText: string): boolean {
+    return REQUIRE_CALL.test(fileText.replace(COMMENT_OR_STRING, " "));
+}
+
+/** The `type` field of the nearest package.json, if it sets one. */
+export function packageTypeFor(startDir: string): string | undefined {
+    let dir = path.resolve(startDir);
+    for (;;) {
+        const candidate = path.join(dir, "package.json");
+        if (fs.existsSync(candidate)) {
+            try {
+                return JSON.parse(readOrEmpty(candidate))?.type;
+            } catch {
+                return undefined;
+            }
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            return undefined;
+        }
+        dir = parent;
+    }
+}
+
+function chooseRunner(
+    filePath: string,
+    cwd: string,
+    options: RunPlanOptions
+): Runner {
+    if (options.forceTsx) {
+        return "tsx";
+    }
+    // Plain JavaScript never needs a compiler, whatever the project config.
+    if (!isTypeScriptFile(filePath)) {
+        return "node";
+    }
+    const text = readOrEmpty(filePath);
+    if (needsTypeScriptCompiler(text)) {
+        return "tsx";
+    }
+    // A package that declares "commonjs" (or a .cts file) never gets Node's
+    // detect-and-reparse rescue, so ESM syntax there is a hard failure.
+    const ext = path.extname(filePath).toLowerCase();
+    const packageType = packageTypeFor(cwd);
+    const alwaysCommonJs = ext === ".cts" || packageType === "commonjs";
+    if (alwaysCommonJs && usesEsmSyntax(text)) {
+        return "tsx";
+    }
+    // The mirror image: `require` does not exist in ESM scope. Node loads the
+    // file as ESM when the extension or package says so, and also when it
+    // reparses a typeless file after spotting module syntax. tsx handles both.
+    const loadedAsEsm =
+        ext === ".mts" ||
+        packageType === "module" ||
+        (!alwaysCommonJs && usesEsmSyntax(text));
+    if (loadedAsEsm && usesRequire(text)) {
+        return "tsx";
+    }
+    if (tsconfigHasPaths(cwd) || tsconfigNeedsBundler(cwd)) {
+        return "tsx";
+    }
+    return "node";
+}
+
+export interface RunnerCommand {
+    /** Executable to spawn. */
+    bin: string;
+    /** Arguments that must precede the run arguments (used by the npx fallback). */
+    prefixArgs: string[];
+}
+
+/**
+ * Resolve how to invoke a runner. When tsx is not installed we fall back to
+ * `npx --yes tsx` rather than refusing: npx serves it from a user-level cache
+ * and leaves package.json, the lockfile and node_modules untouched.
+ */
+export function resolveRunnerCommand(runner: Runner, cwd: string): RunnerCommand {
+    if (runner === "node") {
+        return { bin: process.execPath, prefixArgs: [] };
+    }
+    const local = findLocalBin("tsx", cwd);
+    return local
+        ? { bin: local, prefixArgs: [] }
+        : { bin: "npx", prefixArgs: ["--yes", "tsx"] };
+}
+
+/**
+ * Decide how to run `filePath` with Monocle tracing preloaded.
+ *
+ * Node runs most TypeScript directly by stripping types, so it is the default;
+ * tsx is used only where Node provably cannot cope.
+ */
+export function buildRunPlan(
+    filePath: string,
+    userArgs: string[],
+    options: RunPlanOptions = {}
+): RunPlan {
+    const resolved = path.resolve(filePath);
+    const cwd = projectDirFor(resolved);
+    const text = readOrEmpty(resolved);
+    return {
+        runner: chooseRunner(resolved, cwd, options),
+        args: [
+            preloadFlagFor(resolved, text),
+            "monocle2ai/register",
+            resolved,
+            ...userArgs,
+        ],
+        cwd,
+    };
+}

--- a/src/common/envFile.ts
+++ b/src/common/envFile.ts
@@ -1,0 +1,42 @@
+import * as fs from "fs";
+import * as path from "path";
+import { consoleLog } from "./logging";
+
+/** Monocle's own settings file, kept out of the app's .env. */
+export const MONOCLE_ENV_FILE = ".env.monocle";
+
+export type EnvFileOutcome = "loaded" | "absent" | "unsupported" | "failed";
+
+/**
+ * Load Monocle's settings from .env.monocle.
+ *
+ * Node applies --env-file before startup, so this only has to cover the
+ * runtimes that never see that flag — Next.js and mastra load their own .env
+ * and know nothing of this file. process.loadEnvFile leaves already-set
+ * variables alone, which is the precedence we want: the real environment and
+ * the app's own .env both outrank this file.
+ *
+ * Every failure is reported rather than thrown. The file is optional, and
+ * tracing must not break because it is missing, unreadable, or unsupported.
+ */
+export function loadMonocleEnvFile(dir: string = process.cwd()): EnvFileOutcome {
+    const file = path.join(dir, MONOCLE_ENV_FILE);
+
+    // Added in Node 20.12 / 21.7; older runtimes simply go without.
+    if (typeof process.loadEnvFile !== "function") {
+        consoleLog(`[monocle] this Node cannot read ${MONOCLE_ENV_FILE}`);
+        return "unsupported";
+    }
+    if (!fs.existsSync(file)) {
+        return "absent";
+    }
+
+    try {
+        process.loadEnvFile(file);
+        consoleLog(`[monocle] loaded settings from ${file}`);
+        return "loaded";
+    } catch (err) {
+        consoleLog(`[monocle] could not read ${file}: ${String(err)}`);
+        return "failed";
+    }
+}

--- a/src/common/envFile.ts
+++ b/src/common/envFile.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import { parseEnv } from "util";
+import * as util from "util";
 import { consoleLog } from "./logging";
 
 /** Monocle's own settings file, kept out of the app's .env. */
@@ -27,8 +27,10 @@ export type EnvFileOutcome = "loaded" | "absent" | "unsupported" | "failed";
 export function loadMonocleEnvFile(dir: string = process.cwd()): EnvFileOutcome {
     const file = path.join(dir, MONOCLE_ENV_FILE);
 
-    // parseEnv arrived in Node 20.12 / 21.7; older runtimes go without.
-    if (typeof parseEnv !== "function") {
+    // parseEnv arrived in Node 20.12 / 21.7; older runtimes go without. Reached
+    // through the namespace: a named import of a missing builtin export is a
+    // load-time SyntaxError in ESM, which would take the preload down with it.
+    if (typeof util.parseEnv !== "function") {
         consoleLog(`[monocle] this Node cannot read ${MONOCLE_ENV_FILE}`);
         return "unsupported";
     }
@@ -37,7 +39,7 @@ export function loadMonocleEnvFile(dir: string = process.cwd()): EnvFileOutcome 
     }
 
     try {
-        const settings = parseEnv(fs.readFileSync(file, "utf8"));
+        const settings = util.parseEnv(fs.readFileSync(file, "utf8"));
         for (const [key, value] of Object.entries(settings)) {
             if (typeof value === "string") {
                 process.env[key] = value;

--- a/src/common/envFile.ts
+++ b/src/common/envFile.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import { parseEnv } from "util";
 import { consoleLog } from "./logging";
 
 /** Monocle's own settings file, kept out of the app's .env. */
@@ -10,11 +11,15 @@ export type EnvFileOutcome = "loaded" | "absent" | "unsupported" | "failed";
 /**
  * Load Monocle's settings from .env.monocle.
  *
- * Node applies --env-file before startup, so this only has to cover the
- * runtimes that never see that flag — Next.js and mastra load their own .env
- * and know nothing of this file. process.loadEnvFile leaves already-set
- * variables alone, which is the precedence we want: the real environment and
- * the app's own .env both outrank this file.
+ * This is where Monocle's settings live, so the file is authoritative and its
+ * values replace whatever is already in the environment. Deferring to what was
+ * set earlier is not an option: the preload runs in every process tsx spawns
+ * and only the last of them applies --env-file, so a value from .env would win
+ * under plain node and lose under tsx for the very same project. The app's own
+ * .env carries NODE_OPTIONS and nothing Monocle reads.
+ *
+ * Parsed with Node's own .env parser, so this file and --env-file can never
+ * disagree about what a line means.
  *
  * Every failure is reported rather than thrown. The file is optional, and
  * tracing must not break because it is missing, unreadable, or unsupported.
@@ -22,8 +27,8 @@ export type EnvFileOutcome = "loaded" | "absent" | "unsupported" | "failed";
 export function loadMonocleEnvFile(dir: string = process.cwd()): EnvFileOutcome {
     const file = path.join(dir, MONOCLE_ENV_FILE);
 
-    // Added in Node 20.12 / 21.7; older runtimes simply go without.
-    if (typeof process.loadEnvFile !== "function") {
+    // parseEnv arrived in Node 20.12 / 21.7; older runtimes go without.
+    if (typeof parseEnv !== "function") {
         consoleLog(`[monocle] this Node cannot read ${MONOCLE_ENV_FILE}`);
         return "unsupported";
     }
@@ -32,7 +37,12 @@ export function loadMonocleEnvFile(dir: string = process.cwd()): EnvFileOutcome 
     }
 
     try {
-        process.loadEnvFile(file);
+        const settings = parseEnv(fs.readFileSync(file, "utf8"));
+        for (const [key, value] of Object.entries(settings)) {
+            if (typeof value === "string") {
+                process.env[key] = value;
+            }
+        }
         consoleLog(`[monocle] loaded settings from ${file}`);
         return "loaded";
     } catch (err) {

--- a/src/exporters/index.ts
+++ b/src/exporters/index.ts
@@ -25,7 +25,10 @@ function getMonocleExporters(exporter_list: string = null, options: GetMonocleEx
         consoleLog('getMonocleExporters| Using LambdaExportTaskProcessor for AWS Lambda environment');
         getMonocleExporterOptions.taskProcessor = new LambdaExportTaskProcessor();
     }
-    const exporterNameList = (exporter_list || process.env.MONOCLE_EXPORTER || 'console').split(',');
+    // Files rather than the console: spans printed to a terminal are gone once
+    // the scrollback rolls, and a run started from an editor may have no visible
+    // terminal at all. They land in .monocle/ and can be read back afterwards.
+    const exporterNameList = (exporter_list || process.env.MONOCLE_EXPORTER || 'file').split(',');
     consoleLog(`getMonocleExporters| Initializing exporters with config: ${exporterNameList}`);
 
     let exporters = [];

--- a/src/exporters/index.ts
+++ b/src/exporters/index.ts
@@ -25,9 +25,7 @@ function getMonocleExporters(exporter_list: string = null, options: GetMonocleEx
         consoleLog('getMonocleExporters| Using LambdaExportTaskProcessor for AWS Lambda environment');
         getMonocleExporterOptions.taskProcessor = new LambdaExportTaskProcessor();
     }
-    // Files rather than the console: spans printed to a terminal are gone once
-    // the scrollback rolls, and a run started from an editor may have no visible
-    // terminal at all. They land in .monocle/ and can be read back afterwards.
+   
     const exporterNameList = (exporter_list || process.env.MONOCLE_EXPORTER || 'file').split(',');
     consoleLog(`getMonocleExporters| Initializing exporters with config: ${exporterNameList}`);
 

--- a/src/instrumentation/common/esmModule.ts
+++ b/src/instrumentation/common/esmModule.ts
@@ -4,17 +4,32 @@ import { isVercelEnvironment } from './utils'
 
 export function registerModule() {
     // @esm-only
+
+    // Keep TypeScript sources away from import-in-the-middle: on Node's
+    // CommonJS-then-reparse path IITM claims the file before native type
+    // stripping, so TS syntax reaches V8 and throws. Only node_modules needs wrapping.
+    const TYPESCRIPT_SOURCE = /\.[cm]?tsx?($|\?)/
+
+    // openai v4 keeps its shims in module-level state. Wrapping _shims hands the
+    // writer and the reader different instances, so core.mjs sees an uninitialised
+    // registry and throws. Nothing there is instrumented, so skipping costs nothing.
+    const OPENAI_SHIMS = /[\\/]openai[\\/]_shims[\\/]/
+
     try {
         consoleLog("registering import-in-the-middle/hook.mjs")
 
         import('import-in-the-middle/hook.mjs')
 
         if (isVercelEnvironment()) {
-            module_private_1.register('import-in-the-middle/hook.mjs', "file:///var/task/node_modules")
+            module_private_1.register('import-in-the-middle/hook.mjs', "file:///var/task/node_modules", {
+                data: { exclude: [TYPESCRIPT_SOURCE, OPENAI_SHIMS] }
+            })
         }
         else {
             // @ts-ignore
-            module_private_1.register('import-in-the-middle/hook.mjs', import.meta.url)
+            module_private_1.register('import-in-the-middle/hook.mjs', import.meta.url, {
+                data: { exclude: [TYPESCRIPT_SOURCE, OPENAI_SHIMS] }
+            })
         }
     }
     catch (e) {

--- a/src/instrumentation/common/instrumentation.ts
+++ b/src/instrumentation/common/instrumentation.ts
@@ -23,7 +23,7 @@ import { getMonocleExporters } from '../../exporters';
 import { PatchedBatchSpanProcessor } from './opentelemetryUtils';
 import { AWSS3SpanExporter } from '../../exporters/aws/AWSS3SpanExporter'
 import { consoleLog } from '../../common/logging';
-import { setScopesInternal, getScopesInternal, setScopesBindInternal, load_scopes, setInstrumentor, startTraceInternal } from './utils';
+import { setScopesInternal, getScopesInternal, setScopesBindInternal, load_scopes, setInstrumentor, getInstrumentor, startTraceInternal } from './utils';
 
 class MonocleInstrumentation extends InstrumentationBase {
     // `declare` (no runtime field): a real field would emit `this.x = undefined`
@@ -376,8 +376,20 @@ const setupMonocle = (
 
     try {
         consoleLog(`Setting up Monocle for workflow: ${workflowName}`);
+
         if (spanProcessors.length && exporter_list) {
             throw new Error('Cannot set both spanProcessors and exporter_list.');
+        }
+
+        // Set up once per process: `monocle2ai run` preloads the register entry
+        // and the target file may call setupMonocle too, which would build a
+        // second tracer provider and export every span twice.
+        const existing = getInstrumentor();
+        if (existing) {
+            consoleLog(
+                `Monocle is already set up; ignoring this call for workflow: ${workflowName}`
+            );
+            return existing;
         }
         registerModule();
 

--- a/src/instrumentation/common/instrumentation.ts
+++ b/src/instrumentation/common/instrumentation.ts
@@ -18,6 +18,7 @@ import { AWS_CONSTANTS, MethodConfig } from './constants';
 import * as path from 'path';
 import * as fs from 'fs';
 import { Hook as ImportHook } from "import-in-the-middle";
+import { loadMonocleEnvFile } from "../../common/envFile";
 import { Hook as RequireHook } from "require-in-the-middle";
 import { getMonocleExporters } from '../../exporters';
 import { PatchedBatchSpanProcessor } from './opentelemetryUtils';
@@ -375,6 +376,11 @@ const setupMonocle = (
 ) => {
 
     try {
+        // Before anything reads configuration, and before consoleLog checks
+        // MONOCLE_DEBUG. Next.js and mastra reach tracing through here rather
+        // than through the register preload, so this is their only chance.
+        loadMonocleEnvFile();
+
         consoleLog(`Setting up Monocle for workflow: ${workflowName}`);
 
         if (spanProcessors.length && exporter_list) {

--- a/src/instrumentation/common/utils.ts
+++ b/src/instrumentation/common/utils.ts
@@ -69,7 +69,7 @@ export function setInstrumentor(instrumentor: any) {
     (globalThis as any)[INSTRUMENTOR_KEY] = instrumentor;
 }
 
-function getInstrumentor(): any {
+export function getInstrumentor(): any {
     return (globalThis as any)[INSTRUMENTOR_KEY];
 }
 

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,9 +1,11 @@
 // Preload entry: `--import monocle2ai/register` (or via NODE_OPTIONS). Runs
 // setupMonocle before the app's import graph loads, so IITM can hook it. Kept
 // separate from the exported API so importing the library doesn't start tracing.
-// Service name: MONOCLE_WORKFLOW_NAME (default "monocle-app").
+// Service name: MONOCLE_WORKFLOW_NAME, from the environment or .env.monocle
+// (default "monocle-app").
 import { setupMonocle } from "./instrumentation/common/instrumentation";
 import { DEFAULT_WORKFLOW_NAME } from "./instrumentation/common/constants";
+import { loadMonocleEnvFile } from "./common/envFile";
 
 // Run once per process (tsx spawns helpers that each inherit --import).
 const REGISTERED = Symbol.for("monocle2ai.register.done");
@@ -12,6 +14,9 @@ const g = globalThis as any;
 if (!g[REGISTERED]) {
   g[REGISTERED] = true;
 
+  // Must precede the read below: the workflow name lives in .env.monocle, so
+  // reading it first would name every traced workflow "monocle-app".
+  loadMonocleEnvFile();
   setupMonocle(process.env.MONOCLE_WORKFLOW_NAME ?? DEFAULT_WORKFLOW_NAME);
 
   // Hold the loop briefly on exit so a short script's batched spans flush

--- a/test/unit/cliArgs.test.ts
+++ b/test/unit/cliArgs.test.ts
@@ -16,16 +16,9 @@ describe('parseArgs', () => {
 
   it('does not treat the target script own flags as monocle flags', () => {
     const parsed = parseArgs(['run', 'agent.ts', '--tsx']);
-
-    expect(parsed.forceTsx).toBe(false);
     expect(parsed.userArgs).toEqual(['--tsx']);
   });
 
-  it('accepts --tsx before the file as a monocle flag', () => {
-    const parsed = parseArgs(['run', '--tsx', 'agent.ts']);
-
-    expect(parsed).toMatchObject({ command: 'run', file: 'agent.ts', forceTsx: true });
-  });
 
   it('reports a run with no file as an error', () => {
     expect(parseArgs(['run']).command).toBe('error');
@@ -54,6 +47,5 @@ describe('parseArgs', () => {
     const parsed = parseArgs(['run', 'agent.ts', '--', '--tsx']);
 
     expect(parsed.userArgs).toEqual(['--', '--tsx']);
-    expect(parsed.forceTsx).toBe(false);
   });
 });

--- a/test/unit/cliArgs.test.ts
+++ b/test/unit/cliArgs.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { parseArgs } from '../../src/cli/args';
+
+describe('parseArgs', () => {
+  it('parses a run command with a target file', () => {
+    const parsed = parseArgs(['run', 'agent.ts']);
+
+    expect(parsed).toMatchObject({ command: 'run', file: 'agent.ts', userArgs: [] });
+  });
+
+  it('keeps arguments after the file for the target script', () => {
+    const parsed = parseArgs(['run', 'agent.ts', '--query', 'hello']);
+
+    expect(parsed.userArgs).toEqual(['--query', 'hello']);
+  });
+
+  it('does not treat the target script own flags as monocle flags', () => {
+    const parsed = parseArgs(['run', 'agent.ts', '--tsx']);
+
+    expect(parsed.forceTsx).toBe(false);
+    expect(parsed.userArgs).toEqual(['--tsx']);
+  });
+
+  it('accepts --tsx before the file as a monocle flag', () => {
+    const parsed = parseArgs(['run', '--tsx', 'agent.ts']);
+
+    expect(parsed).toMatchObject({ command: 'run', file: 'agent.ts', forceTsx: true });
+  });
+
+  it('reports a run with no file as an error', () => {
+    expect(parseArgs(['run']).command).toBe('error');
+  });
+
+  it('treats --help as help', () => {
+    expect(parseArgs(['--help']).command).toBe('help');
+  });
+
+  it('treats no arguments as help', () => {
+    expect(parseArgs([]).command).toBe('help');
+  });
+
+  it('treats --version as version', () => {
+    expect(parseArgs(['--version']).command).toBe('version');
+  });
+
+  it('reports an unknown command as an error rather than guessing', () => {
+    const parsed = parseArgs(['frobnicate', 'agent.ts']);
+
+    expect(parsed.command).toBe('error');
+    expect(parsed.message).toContain('frobnicate');
+  });
+
+  it('passes a -- separator through to the script without consuming it', () => {
+    const parsed = parseArgs(['run', 'agent.ts', '--', '--tsx']);
+
+    expect(parsed.userArgs).toEqual(['--', '--tsx']);
+    expect(parsed.forceTsx).toBe(false);
+  });
+});

--- a/test/unit/cliMessages.test.ts
+++ b/test/unit/cliMessages.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { missingTsxMessage } from '../../src/cli';
+
+describe('missingTsxMessage', () => {
+  const message = () => missingTsxMessage('src/scripts/run-agent.ts');
+
+  it('names the file that needs tsx', () => {
+    expect(message()).toContain('run-agent.ts');
+  });
+
+  it('tells the user how to install tsx', () => {
+    expect(message()).toContain('npm install -D tsx');
+  });
+
+  // The CLI is the one interface users should learn. Sending them to the raw
+  // preload here taught them a second, lower-level way to do the same thing.
+  it('points back at the same monocle2ai command rather than a raw preload', () => {
+    expect(message()).toContain('monocle2ai run src/scripts/run-agent.ts');
+  });
+
+  it('does not leak the --import preload flag as an alternative interface', () => {
+    expect(message()).not.toContain('--import');
+  });
+
+  it('does not suggest invoking the register entry directly', () => {
+    expect(message()).not.toContain('monocle2ai/register');
+  });
+});

--- a/test/unit/cliRunOnce.test.ts
+++ b/test/unit/cliRunOnce.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { runOnce } from '../../src/cli';
+import { buildRunPlan } from '../../src/cli/runPlan';
+
+let root: string;
+const write = (rel: string, body = '') => {
+  const full = path.join(root, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, body);
+  return full;
+};
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'monocle-run-'));
+  write('package.json', '{}');
+  write('node_modules/tsx/package.json', JSON.stringify({ bin: './dist/cli.mjs' }));
+  write('node_modules/tsx/dist/cli.mjs', '// tsx');
+});
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('runOnce', () => {
+  // Node emits only EACCES/EAGAIN/EMFILE/ENFILE/ENOENT as 'error' events and
+  // throws every other spawn failure. On Windows that throw is EINVAL for .cmd
+  // files; ENOTDIR reproduces the same class here, through a path whose parent
+  // is a file. Unguarded it escapes the executor as a raw Node stack, which is
+  // why the reported failure showed no Monocle message at all.
+  it('reports a spawn failure that Node throws instead of emitting', async () => {
+    const file = write('agent.ts', 'export {};');
+
+    const outcome = await runOnce(buildRunPlan(file, []), '/etc/hosts/node');
+
+    expect(outcome.code).toBe(1);
+    expect(outcome.spawnError).toMatch(/ENOTDIR/);
+  });
+
+  it('does not reject, so the CLI can turn the failure into guidance', async () => {
+    const file = write('agent.ts', 'export {};');
+
+    await expect(
+      runOnce(buildRunPlan(file, []), '/etc/hosts/node')
+    ).resolves.toBeDefined();
+  });
+});

--- a/test/unit/cliRunPlan.test.ts
+++ b/test/unit/cliRunPlan.test.ts
@@ -6,7 +6,8 @@ import {
   preloadFlagFor,
   projectDirFor,
   buildRunPlan,
-  findLocalBin,
+  findTsxEntry,
+  findNpxCli,
   resolveRunnerCommand,
 } from '../../src/cli/runPlan';
 
@@ -137,46 +138,129 @@ describe('buildRunPlan', () => {
   });
 });
 
-describe('findLocalBin', () => {
-  it('finds a binary in the starting directory', () => {
-    const bin = write('node_modules/.bin/tsx', '#!/bin/sh');
+const installTsx = (bin: unknown = './dist/cli.mjs') => {
+  write(`node_modules/tsx/package.json`, JSON.stringify({ name: 'tsx', bin }));
+  return write(`node_modules/tsx/dist/cli.mjs`, '// tsx');
+};
 
-    expect(findLocalBin('tsx', root)).toBe(bin);
+describe('findTsxEntry', () => {
+  it('resolves the JS entry point of the installed tsx package', () => {
+    const entry = installTsx();
+
+    expect(findTsxEntry(root)).toBe(entry);
   });
 
-  it('walks up to a hoisted binary, as module resolution does', () => {
-    const bin = write('node_modules/.bin/tsx', '#!/bin/sh');
+  // node_modules/.bin holds shell shims, and Windows ships tsx.cmd there.
+  // Node refuses to spawn a .cmd without a shell, so the entry must be a plain
+  // JS file we can hand to the node binary ourselves.
+  it('never returns a shim from node_modules/.bin', () => {
+    installTsx();
+    write('node_modules/.bin/tsx.cmd', '@echo off');
+    write('node_modules/.bin/tsx', '#!/bin/sh');
+
+    expect(findTsxEntry(root)).toMatch(/dist[\\/]cli\.mjs$/);
+  });
+
+  it('walks up to a hoisted tsx, as module resolution does', () => {
+    const entry = installTsx();
     const nested = path.join(root, 'packages/api');
     fs.mkdirSync(nested, { recursive: true });
 
-    expect(findLocalBin('tsx', nested)).toBe(bin);
+    expect(findTsxEntry(nested)).toBe(entry);
   });
 
-  it('returns undefined when the binary is nowhere up the tree', () => {
-    expect(findLocalBin('tsx', root)).toBeUndefined();
+  it('reads the object form of the bin field', () => {
+    const entry = installTsx({ tsx: './dist/cli.mjs' });
+
+    expect(findTsxEntry(root)).toBe(entry);
+  });
+
+  it('returns undefined when tsx is nowhere up the tree', () => {
+    expect(findTsxEntry(root)).toBeUndefined();
+  });
+
+  it('returns undefined when the manifest points at a file that is not there', () => {
+    write('node_modules/tsx/package.json', JSON.stringify({ bin: './dist/cli.mjs' }));
+
+    expect(findTsxEntry(root)).toBeUndefined();
+  });
+
+  it('returns undefined when the manifest cannot be parsed', () => {
+    write('node_modules/tsx/package.json', 'not json');
+
+    expect(findTsxEntry(root)).toBeUndefined();
+  });
+});
+
+describe('findNpxCli', () => {
+  it('finds npx-cli.js beside the node binary, the layout Windows installs use', () => {
+    const cli = write('nodedir/node_modules/npm/bin/npx-cli.js', '// npx');
+
+    expect(findNpxCli(path.join(root, 'nodedir/node.exe'))).toBe(cli);
+  });
+
+  it('finds npx-cli.js under lib, the layout POSIX installs use', () => {
+    const cli = write('lib/node_modules/npm/bin/npx-cli.js', '// npx');
+
+    expect(findNpxCli(path.join(root, 'bin/node'))).toBe(cli);
+  });
+
+  it('returns undefined when npm is not installed beside node', () => {
+    expect(findNpxCli(path.join(root, 'bin/node'))).toBeUndefined();
   });
 });
 
 describe('resolveRunnerCommand', () => {
-  it('prefers a tsx installed in the project', () => {
-    const bin = write('node_modules/.bin/tsx', '#!/bin/sh');
+  const posix = '/usr/bin/node';
+  const win = 'C:\\nodejs\\node.exe';
 
-    expect(resolveRunnerCommand(root)).toEqual({ bin, prefixArgs: [] });
+  it('runs the tsx entry through the node binary already running', () => {
+    const entry = installTsx();
+
+    expect(resolveRunnerCommand(root, posix)).toEqual({
+      bin: posix,
+      prefixArgs: [entry],
+      usedNpx: false,
+    });
   });
 
-  // npx resolves tsx from a user-level cache (~/.npm/_npx) and leaves
-  // package.json, the lockfile and node_modules untouched — verified.
-  it('falls back to npx when tsx is not installed, rather than refusing to run', () => {
-    expect(resolveRunnerCommand(root)).toEqual({
+  // The reported bug: Node >= 18.20.2 returns EINVAL rather than spawning a
+  // .cmd without a shell, and EINVAL is thrown rather than emitted.
+  it('spawns no .cmd shim on Windows when tsx is installed', () => {
+    installTsx();
+    write('node_modules/.bin/tsx.cmd', '@echo off');
+
+    const command = resolveRunnerCommand(root, win);
+
+    expect(command.bin).toBe(win);
+    expect([command.bin, ...command.prefixArgs].join(' ')).not.toMatch(/\.(cmd|bat)$/im);
+  });
+
+  it("falls back to npm's own npx-cli.js through node, which needs no shell", () => {
+    const cli = write('nodedir/node_modules/npm/bin/npx-cli.js', '// npx');
+    const execPath = path.join(root, 'nodedir/node.exe');
+
+    expect(resolveRunnerCommand(root, execPath)).toEqual({
+      bin: execPath,
+      prefixArgs: [cli, '--yes', 'tsx'],
+      usedNpx: true,
+    });
+  });
+
+  // Last resort: npx is on PATH as a shell script on POSIX, so this still works
+  // there; on Windows it fails, and the CLI turns that into install guidance.
+  it('falls back to the npx command when npm cannot be located beside node', () => {
+    expect(resolveRunnerCommand(root, posix)).toEqual({
       bin: 'npx',
       prefixArgs: ['--yes', 'tsx'],
+      usedNpx: true,
     });
   });
 
   it('reports whether the fallback is in use so the CLI can say so', () => {
-    expect(resolveRunnerCommand(root).bin).toBe('npx');
+    expect(resolveRunnerCommand(root, posix).usedNpx).toBe(true);
 
-    write('node_modules/.bin/tsx', '#!/bin/sh');
-    expect(resolveRunnerCommand(root).bin).not.toBe('npx');
+    installTsx();
+    expect(resolveRunnerCommand(root, posix).usedNpx).toBe(false);
   });
 });

--- a/test/unit/cliRunPlan.test.ts
+++ b/test/unit/cliRunPlan.test.ts
@@ -1,0 +1,522 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  isTypeScriptFile,
+  preloadFlagFor,
+  needsTypeScriptCompiler,
+  isCompilerError,
+  projectDirFor,
+  tsconfigHasPaths,
+  buildRunPlan,
+  findLocalBin,
+  usesEsmSyntax,
+  packageTypeFor,
+  tsconfigNeedsBundler,
+  resolveRunnerCommand,
+} from '../../src/cli/runPlan';
+
+let root: string;
+const write = (rel: string, body = '') => {
+  const full = path.join(root, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, body);
+  return full;
+};
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'monocle-cli-'));
+});
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('isTypeScriptFile', () => {
+  it.each(['agent.ts', 'page.tsx', 'a.mts', 'a.cts'])('treats %s as TypeScript', (f) => {
+    expect(isTypeScriptFile(f)).toBe(true);
+  });
+
+  it.each(['agent.js', 'a.mjs', 'a.cjs'])('treats %s as JavaScript', (f) => {
+    expect(isTypeScriptFile(f)).toBe(false);
+  });
+});
+
+describe('preloadFlagFor', () => {
+  // A CommonJS module loaded through the ESM loader hits import-in-the-middle's
+  // sync-require path, which fails with "is not in cache". So the flag has to
+  // follow the file's actual syntax, not just its extension.
+  it('uses --require for .cts, which cannot go through the ESM loader', () => {
+    expect(preloadFlagFor('agent.cts')).toBe('--require');
+  });
+
+  it('uses --require for .cjs', () => {
+    expect(preloadFlagFor('agent.cjs')).toBe('--require');
+  });
+
+  it.each(['agent.mts', 'agent.mjs'])('uses --import for %s regardless of contents', (f) => {
+    expect(preloadFlagFor(f, 'const a = require("a");')).toBe('--import');
+  });
+
+  it('uses --import for a .ts file written with ESM imports', () => {
+    expect(preloadFlagFor('agent.ts', 'import OpenAI from "openai";')).toBe('--import');
+  });
+
+  it('uses --require for a .ts file written with require', () => {
+    expect(preloadFlagFor('agent.ts', 'const a = require("a");')).toBe('--require');
+  });
+
+  it('uses --require for a .js file written with require', () => {
+    expect(preloadFlagFor('agent.js', 'const a = require("a");')).toBe('--require');
+  });
+
+  it('uses --import for a .ts file with an export statement', () => {
+    expect(preloadFlagFor('agent.ts', 'export const a = 1;')).toBe('--import');
+  });
+
+  it('defaults to --import when the contents are unknown', () => {
+    expect(preloadFlagFor('agent.ts')).toBe('--import');
+  });
+});
+
+describe('needsTypeScriptCompiler', () => {
+  it('flags an enum, which Node cannot strip', () => {
+    expect(needsTypeScriptCompiler('enum Level { Low, High }')).toBe(true);
+  });
+
+  it('flags an exported const enum', () => {
+    expect(needsTypeScriptCompiler('export const enum E { A }')).toBe(true);
+  });
+
+  it('flags a namespace', () => {
+    expect(needsTypeScriptCompiler('namespace Utils { export const a = 1; }')).toBe(true);
+  });
+
+  it('flags a decorator', () => {
+    expect(needsTypeScriptCompiler('@Injectable()\nclass Service {}')).toBe(true);
+  });
+
+  it('flags a constructor parameter property', () => {
+    expect(needsTypeScriptCompiler('class A { constructor(private x: number) {} }')).toBe(true);
+  });
+
+  it('does not flag ordinary type annotations, which Node strips fine', () => {
+    expect(needsTypeScriptCompiler('const a: string = "x";\ninterface B { c: number }')).toBe(false);
+  });
+
+  it('does not flag plain imports', () => {
+    expect(needsTypeScriptCompiler('import OpenAI from "openai";')).toBe(false);
+  });
+
+  it('does not flag the word enum inside a string', () => {
+    expect(needsTypeScriptCompiler('const s = "an enum value";')).toBe(false);
+  });
+
+  it('does not flag an email-like @ inside an expression', () => {
+    expect(needsTypeScriptCompiler('const to = "a@b.com";')).toBe(false);
+  });
+});
+
+describe('isCompilerError', () => {
+  it('recognises unsupported TypeScript syntax', () => {
+    expect(isCompilerError('SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]: enum')).toBe(true);
+  });
+
+  it('recognises an unresolved module, which is how path aliases fail', () => {
+    expect(isCompilerError("Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@/lib'")).toBe(true);
+  });
+
+  it('does not treat an ordinary runtime error as a compiler problem', () => {
+    expect(isCompilerError('TypeError: x is not a function')).toBe(false);
+  });
+});
+
+describe('projectDirFor', () => {
+  it('returns the directory of the nearest package.json', () => {
+    write('packages/api/package.json', '{}');
+    const file = write('packages/api/src/agent.ts');
+
+    expect(projectDirFor(file)).toBe(path.join(root, 'packages/api'));
+  });
+
+  it('walks up to a parent package.json when there is no nearer one', () => {
+    write('package.json', '{}');
+    const file = write('src/deep/agent.ts');
+
+    expect(projectDirFor(file)).toBe(root);
+  });
+
+  it("falls back to the file's own directory when no package.json exists", () => {
+    const file = write('loose/agent.ts');
+
+    expect(projectDirFor(file)).toBe(path.join(root, 'loose'));
+  });
+});
+
+describe('tsconfigHasPaths', () => {
+  it('detects path aliases, which Node cannot resolve', () => {
+    write('tsconfig.json', JSON.stringify({ compilerOptions: { paths: { '@/*': ['src/*'] } } }));
+
+    expect(tsconfigHasPaths(root)).toBe(true);
+  });
+
+  it('returns false for a tsconfig without paths', () => {
+    write('tsconfig.json', JSON.stringify({ compilerOptions: { target: 'es2022' } }));
+
+    expect(tsconfigHasPaths(root)).toBe(false);
+  });
+
+  it('returns false when there is no tsconfig at all', () => {
+    expect(tsconfigHasPaths(root)).toBe(false);
+  });
+
+  it('tolerates a malformed tsconfig rather than throwing', () => {
+    write('tsconfig.json', '{ not json');
+
+    expect(tsconfigHasPaths(root)).toBe(false);
+  });
+});
+
+describe('buildRunPlan', () => {
+  it('runs plain CommonJS JavaScript on node with the require preload', () => {
+    write('package.json', '{}');
+    const file = write('agent.js', 'const a = require("a");');
+
+    const plan = buildRunPlan(file, []);
+
+    expect(plan.runner).toBe('node');
+    expect(plan.args).toEqual(['--require', 'monocle2ai/register', file]);
+    expect(plan.cwd).toBe(root);
+  });
+
+  it('runs ESM JavaScript on node with the import preload', () => {
+    write('package.json', JSON.stringify({ type: 'module' }));
+    const file = write('agent.js', 'import a from "a";');
+
+    const plan = buildRunPlan(file, []);
+
+    expect(plan.args).toEqual(['--import', 'monocle2ai/register', file]);
+  });
+
+  it('runs ordinary TypeScript on node, since Node can strip plain types', () => {
+    write('package.json', '{}');
+    const file = write('agent.ts', 'const a: string = "x";');
+
+    expect(buildRunPlan(file, []).runner).toBe('node');
+  });
+
+  it('chooses tsx when the file uses syntax Node cannot strip', () => {
+    write('package.json', '{}');
+    const file = write('agent.ts', 'enum Level { Low }');
+
+    expect(buildRunPlan(file, []).runner).toBe('tsx');
+  });
+
+  it('chooses tsx when the project uses tsconfig path aliases', () => {
+    write('package.json', '{}');
+    write('tsconfig.json', JSON.stringify({ compilerOptions: { paths: { '@/*': ['src/*'] } } }));
+    const file = write('agent.ts', 'import { a } from "@/lib";');
+
+    expect(buildRunPlan(file, []).runner).toBe('tsx');
+  });
+
+  it('does not force tsx for path aliases when the target is plain JavaScript', () => {
+    write('package.json', '{}');
+    write('tsconfig.json', JSON.stringify({ compilerOptions: { paths: { '@/*': ['src/*'] } } }));
+    const file = write('agent.js', 'const a = 1;');
+
+    expect(buildRunPlan(file, []).runner).toBe('node');
+  });
+
+  it('honours an explicit tsx request', () => {
+    write('package.json', '{}');
+    const file = write('agent.ts', 'const a = 1;');
+
+    expect(buildRunPlan(file, [], { forceTsx: true }).runner).toBe('tsx');
+  });
+
+  it('passes the user arguments after the script, so the target sees its own argv', () => {
+    write('package.json', '{}');
+    const file = write('agent.js');
+
+    const plan = buildRunPlan(file, ['--query', 'hello world']);
+
+    expect(plan.args).toEqual([
+      '--import',
+      'monocle2ai/register',
+      file,
+      '--query',
+      'hello world',
+    ]);
+  });
+
+  it('uses the require preload for a .cts target', () => {
+    write('package.json', '{}');
+    const file = write('agent.cts', 'const a = require("a");');
+
+    expect(buildRunPlan(file, []).args[0]).toBe('--require');
+  });
+});
+
+describe('findLocalBin', () => {
+  it('finds a binary in the starting directory node_modules', () => {
+    const bin = write('node_modules/.bin/tsx', '#!/bin/sh');
+
+    expect(findLocalBin('tsx', root)).toBe(bin);
+  });
+
+  // npm hoists binaries to the workspace root, so a nested package's cwd will
+  // not contain them.
+  it('walks up to an ancestor node_modules, the way node resolution does', () => {
+    const bin = write('node_modules/.bin/tsx', '#!/bin/sh');
+    fs.mkdirSync(path.join(root, 'packages/api/src'), { recursive: true });
+
+    expect(findLocalBin('tsx', path.join(root, 'packages/api/src'))).toBe(bin);
+  });
+
+  it('returns undefined when the binary is nowhere to be found', () => {
+    fs.mkdirSync(path.join(root, 'empty'), { recursive: true });
+
+    expect(findLocalBin('definitely-not-installed-xyz', path.join(root, 'empty'))).toBeUndefined();
+  });
+});
+
+describe('usesEsmSyntax', () => {
+  it('detects an export statement', () => {
+    expect(usesEsmSyntax('export async function main() {}')).toBe(true);
+  });
+
+  it('detects an import statement', () => {
+    expect(usesEsmSyntax('import OpenAI from "openai";')).toBe(true);
+  });
+
+  it('detects export default', () => {
+    expect(usesEsmSyntax('export default function () {}')).toBe(true);
+  });
+
+  it('does not flag a file using only require and module.exports', () => {
+    const text = 'const a = require("a");\nmodule.exports = { a };';
+
+    expect(usesEsmSyntax(text)).toBe(false);
+  });
+
+  it('does not flag the word export inside a string', () => {
+    expect(usesEsmSyntax('const s = "export this";')).toBe(false);
+  });
+});
+
+describe('packageTypeFor', () => {
+  it('reads an explicit commonjs type', () => {
+    write('package.json', JSON.stringify({ type: 'commonjs' }));
+
+    expect(packageTypeFor(root)).toBe('commonjs');
+  });
+
+  it('reads an explicit module type', () => {
+    write('package.json', JSON.stringify({ type: 'module' }));
+
+    expect(packageTypeFor(root)).toBe('module');
+  });
+
+  it('returns undefined when no type field is set', () => {
+    write('package.json', JSON.stringify({ name: 'x' }));
+
+    expect(packageTypeFor(root)).toBeUndefined();
+  });
+});
+
+describe('buildRunPlan - ESM syntax inside an explicitly CommonJS package', () => {
+  // Node strips types but cannot rewrite `export` into `exports.x`; that is a
+  // transform, not an erasure. With an explicit "type": "commonjs" Node also
+  // refuses to reparse the file as ESM, so it fails outright.
+  it('chooses tsx when an explicitly-commonjs package uses export syntax', () => {
+    write('package.json', JSON.stringify({ type: 'commonjs' }));
+    const file = write('agent.ts', 'const a = require("a");\nexport function go() {}');
+
+    expect(buildRunPlan(file, []).runner).toBe('tsx');
+  });
+
+  it('stays on node for an explicitly-commonjs package written purely in CommonJS', () => {
+    write('package.json', JSON.stringify({ type: 'commonjs' }));
+    const file = write('agent.ts', 'const a = require("a");\nmodule.exports = a;');
+
+    expect(buildRunPlan(file, []).runner).toBe('node');
+  });
+
+  // A package with no "type" lets Node detect ESM syntax and reparse, which works.
+  it('stays on node when the package has no type field', () => {
+    write('package.json', JSON.stringify({ name: 'x' }));
+    const file = write('agent.ts', 'import OpenAI from "openai";');
+
+    expect(buildRunPlan(file, []).runner).toBe('node');
+  });
+
+  it('stays on node for a type:module package', () => {
+    write('package.json', JSON.stringify({ type: 'module' }));
+    const file = write('agent.ts', 'import OpenAI from "openai";');
+
+    expect(buildRunPlan(file, []).runner).toBe('node');
+  });
+
+  it('chooses tsx for a .cts file using export syntax, which is always CommonJS', () => {
+    write('package.json', JSON.stringify({ name: 'x' }));
+    const file = write('agent.cts', 'export function go() {}');
+
+    expect(buildRunPlan(file, []).runner).toBe('tsx');
+  });
+});
+
+describe('isCompilerError - ESM syntax rejected by a CommonJS loader', () => {
+  it("recognises an unexpected export token", () => {
+    expect(isCompilerError("SyntaxError: Unexpected token 'export'")).toBe(true);
+  });
+
+  it('recognises an import statement outside a module', () => {
+    expect(isCompilerError('SyntaxError: Cannot use import statement outside a module')).toBe(true);
+  });
+
+  it('still ignores an ordinary runtime error', () => {
+    expect(isCompilerError('TypeError: undefined is not a function')).toBe(false);
+  });
+});
+
+describe('tsconfigNeedsBundler', () => {
+  // "bundler" resolution lets imports omit file extensions. Node's ESM loader
+  // requires them, so such a project cannot run on plain node.
+  it('detects bundler module resolution', () => {
+    write('tsconfig.json', JSON.stringify({ compilerOptions: { moduleResolution: 'bundler' } }));
+
+    expect(tsconfigNeedsBundler(root)).toBe(true);
+  });
+
+  it('is case-insensitive, since tsconfig values often are', () => {
+    write('tsconfig.json', JSON.stringify({ compilerOptions: { moduleResolution: 'Bundler' } }));
+
+    expect(tsconfigNeedsBundler(root)).toBe(true);
+  });
+
+  it('returns false for nodenext resolution', () => {
+    write('tsconfig.json', JSON.stringify({ compilerOptions: { moduleResolution: 'NodeNext' } }));
+
+    expect(tsconfigNeedsBundler(root)).toBe(false);
+  });
+
+  it('returns false when there is no tsconfig', () => {
+    expect(tsconfigNeedsBundler(root)).toBe(false);
+  });
+});
+
+describe('buildRunPlan - bundler-style projects', () => {
+  it('chooses tsx when the project uses bundler module resolution', () => {
+    write('package.json', JSON.stringify({ type: 'module' }));
+    write('tsconfig.json', JSON.stringify({ compilerOptions: { moduleResolution: 'bundler' } }));
+    const file = write('agent.ts', 'import { a } from "./thing";');
+
+    expect(buildRunPlan(file, []).runner).toBe('tsx');
+  });
+
+  it('leaves plain JavaScript on node even in a bundler project', () => {
+    write('package.json', JSON.stringify({ type: 'module' }));
+    write('tsconfig.json', JSON.stringify({ compilerOptions: { moduleResolution: 'bundler' } }));
+    const file = write('agent.js', 'const a = 1;');
+
+    expect(buildRunPlan(file, []).runner).toBe('node');
+  });
+});
+
+describe('resolveRunnerCommand', () => {
+  it('runs node with the interpreter already executing this CLI', () => {
+    expect(resolveRunnerCommand('node', root)).toEqual({
+      bin: process.execPath,
+      prefixArgs: [],
+    });
+  });
+
+  it('prefers a tsx installed in the project', () => {
+    const bin = write('node_modules/.bin/tsx', '#!/bin/sh');
+
+    expect(resolveRunnerCommand('tsx', root)).toEqual({ bin, prefixArgs: [] });
+  });
+
+  // npx resolves tsx from a user-level cache (~/.npm/_npx) and leaves
+  // package.json, the lockfile and node_modules untouched — verified.
+  it('falls back to npx when tsx is not installed, rather than refusing to run', () => {
+    expect(resolveRunnerCommand('tsx', root)).toEqual({
+      bin: 'npx',
+      prefixArgs: ['--yes', 'tsx'],
+    });
+  });
+
+  it('reports whether the fallback is in use so the CLI can say so', () => {
+    expect(resolveRunnerCommand('tsx', root).bin).toBe('npx');
+
+    write('node_modules/.bin/tsx', '#!/bin/sh');
+    expect(resolveRunnerCommand('tsx', root).bin).not.toBe('npx');
+  });
+});
+
+describe('buildRunPlan - files that mix require() with ESM syntax', () => {
+  // Node parses a typeless file as CommonJS first, then reparses it as ESM the
+  // moment it spots module syntax. That rescue is what makes a pure-ESM file
+  // work — and what breaks a file that also calls require(), since `require`
+  // does not exist in ESM scope. tsx compiles both forms down to CommonJS.
+  const MIXED = "require('dotenv/config');\nconst { a } = require('a');\nexport {};";
+
+  it('chooses tsx for a typeless package whose file mixes require with export', () => {
+    write('package.json', JSON.stringify({ name: 'x' }));
+    const file = write('agent.ts', MIXED);
+
+    expect(buildRunPlan(file, []).runner).toBe('tsx');
+  });
+
+  it('chooses tsx when the ESM marker is a bare `export {}` at the end of the file', () => {
+    write('package.json', JSON.stringify({ name: 'x' }));
+    const file = write('agent.ts', "const a = require('a');\na();\nexport {};");
+
+    expect(buildRunPlan(file, []).runner).toBe('tsx');
+  });
+
+  it('chooses tsx for a type:module package whose file calls require', () => {
+    write('package.json', JSON.stringify({ type: 'module' }));
+    const file = write('agent.ts', "const a = require('a');\nexport {};");
+
+    expect(buildRunPlan(file, []).runner).toBe('tsx');
+  });
+
+  it('chooses tsx for a type:module package written entirely in CommonJS', () => {
+    // No ESM syntax to trigger a reparse, but "type": "module" already forces
+    // ESM, so require is undefined here too.
+    write('package.json', JSON.stringify({ type: 'module' }));
+    const file = write('agent.ts', "const a = require('a');\nmodule.exports = a;");
+
+    expect(buildRunPlan(file, []).runner).toBe('tsx');
+  });
+
+  it('stays on node for a typeless package written purely in ESM', () => {
+    write('package.json', JSON.stringify({ name: 'x' }));
+    const file = write('agent.ts', "import OpenAI from 'openai';\nexport {};");
+
+    expect(buildRunPlan(file, []).runner).toBe('node');
+  });
+
+  it('stays on node for a typeless package written purely in CommonJS', () => {
+    write('package.json', JSON.stringify({ name: 'x' }));
+    const file = write('agent.ts', "const a = require('a');\nmodule.exports = a;");
+
+    expect(buildRunPlan(file, []).runner).toBe('node');
+  });
+
+  it('does not mistake the word require inside an identifier for a call', () => {
+    write('package.json', JSON.stringify({ type: 'module' }));
+    const file = write('agent.ts', "const requireAuth = true;\nexport { requireAuth };");
+
+    expect(buildRunPlan(file, []).runner).toBe('node');
+  });
+
+  it('does not mistake a string mentioning require for a call', () => {
+    write('package.json', JSON.stringify({ type: 'module' }));
+    const file = write('agent.ts', "export const hint = 'use require() instead';");
+
+    expect(buildRunPlan(file, []).runner).toBe('node');
+  });
+});

--- a/test/unit/cliRunPlan.test.ts
+++ b/test/unit/cliRunPlan.test.ts
@@ -3,17 +3,10 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
-  isTypeScriptFile,
   preloadFlagFor,
-  needsTypeScriptCompiler,
-  isCompilerError,
   projectDirFor,
-  tsconfigHasPaths,
   buildRunPlan,
   findLocalBin,
-  usesEsmSyntax,
-  packageTypeFor,
-  tsconfigNeedsBundler,
   resolveRunnerCommand,
 } from '../../src/cli/runPlan';
 
@@ -32,216 +25,80 @@ afterEach(() => {
   fs.rmSync(root, { recursive: true, force: true });
 });
 
-describe('isTypeScriptFile', () => {
-  it.each(['agent.ts', 'page.tsx', 'a.mts', 'a.cts'])('treats %s as TypeScript', (f) => {
-    expect(isTypeScriptFile(f)).toBe(true);
-  });
-
-  it.each(['agent.js', 'a.mjs', 'a.cjs'])('treats %s as JavaScript', (f) => {
-    expect(isTypeScriptFile(f)).toBe(false);
-  });
-});
-
 describe('preloadFlagFor', () => {
-  // A CommonJS module loaded through the ESM loader hits import-in-the-middle's
-  // sync-require path, which fails with "is not in cache". So the flag has to
-  // follow the file's actual syntax, not just its extension.
-  it('uses --require for .cts, which cannot go through the ESM loader', () => {
+  // tsx compiles the target whatever its module system, so the flag no longer
+  // depends on the package type or the file's own syntax — only on .cts, which
+  // import-in-the-middle cannot load through --import.
+  it.each(['agent.ts', 'agent.tsx', 'agent.js', 'agent.mjs', 'agent.mts', 'agent.cjs'])(
+    'uses the import preload for %s',
+    (f) => {
+      expect(preloadFlagFor(f)).toBe('--import');
+    }
+  );
+
+  it('uses the require preload for .cts, which breaks IITM under --import', () => {
     expect(preloadFlagFor('agent.cts')).toBe('--require');
   });
 
-  it('uses --require for .cjs', () => {
-    expect(preloadFlagFor('agent.cjs')).toBe('--require');
+  it('ignores the case of the extension', () => {
+    expect(preloadFlagFor('AGENT.CTS')).toBe('--require');
   });
 
-  it.each(['agent.mts', 'agent.mjs'])('uses --import for %s regardless of contents', (f) => {
-    expect(preloadFlagFor(f, 'const a = require("a");')).toBe('--import');
-  });
-
-  it('uses --import for a .ts file written with ESM imports', () => {
-    expect(preloadFlagFor('agent.ts', 'import OpenAI from "openai";')).toBe('--import');
-  });
-
-  it('uses --require for a .ts file written with require', () => {
-    expect(preloadFlagFor('agent.ts', 'const a = require("a");')).toBe('--require');
-  });
-
-  it('uses --require for a .js file written with require', () => {
-    expect(preloadFlagFor('agent.js', 'const a = require("a");')).toBe('--require');
-  });
-
-  it('uses --import for a .ts file with an export statement', () => {
-    expect(preloadFlagFor('agent.ts', 'export const a = 1;')).toBe('--import');
-  });
-
-  it('defaults to --import when the contents are unknown', () => {
-    expect(preloadFlagFor('agent.ts')).toBe('--import');
-  });
-});
-
-describe('needsTypeScriptCompiler', () => {
-  it('flags an enum, which Node cannot strip', () => {
-    expect(needsTypeScriptCompiler('enum Level { Low, High }')).toBe(true);
-  });
-
-  it('flags an exported const enum', () => {
-    expect(needsTypeScriptCompiler('export const enum E { A }')).toBe(true);
-  });
-
-  it('flags a namespace', () => {
-    expect(needsTypeScriptCompiler('namespace Utils { export const a = 1; }')).toBe(true);
-  });
-
-  it('flags a decorator', () => {
-    expect(needsTypeScriptCompiler('@Injectable()\nclass Service {}')).toBe(true);
-  });
-
-  it('flags a constructor parameter property', () => {
-    expect(needsTypeScriptCompiler('class A { constructor(private x: number) {} }')).toBe(true);
-  });
-
-  it('does not flag ordinary type annotations, which Node strips fine', () => {
-    expect(needsTypeScriptCompiler('const a: string = "x";\ninterface B { c: number }')).toBe(false);
-  });
-
-  it('does not flag plain imports', () => {
-    expect(needsTypeScriptCompiler('import OpenAI from "openai";')).toBe(false);
-  });
-
-  it('does not flag the word enum inside a string', () => {
-    expect(needsTypeScriptCompiler('const s = "an enum value";')).toBe(false);
-  });
-
-  it('does not flag an email-like @ inside an expression', () => {
-    expect(needsTypeScriptCompiler('const to = "a@b.com";')).toBe(false);
-  });
-});
-
-describe('isCompilerError', () => {
-  it('recognises unsupported TypeScript syntax', () => {
-    expect(isCompilerError('SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]: enum')).toBe(true);
-  });
-
-  it('recognises an unresolved module, which is how path aliases fail', () => {
-    expect(isCompilerError("Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@/lib'")).toBe(true);
-  });
-
-  it('does not treat an ordinary runtime error as a compiler problem', () => {
-    expect(isCompilerError('TypeError: x is not a function')).toBe(false);
+  it('does not depend on the file contents', () => {
+    // A path that does not exist still yields a flag — nothing is read.
+    expect(preloadFlagFor('/nowhere/agent.ts')).toBe('--import');
   });
 });
 
 describe('projectDirFor', () => {
-  it('returns the directory of the nearest package.json', () => {
+  it('returns the directory holding the nearest package.json', () => {
+    write('package.json', '{}');
+    const file = write('src/agent.ts');
+
+    expect(projectDirFor(file)).toBe(root);
+  });
+
+  it('prefers a nested package.json over one further up', () => {
+    write('package.json', '{}');
     write('packages/api/package.json', '{}');
     const file = write('packages/api/src/agent.ts');
 
     expect(projectDirFor(file)).toBe(path.join(root, 'packages/api'));
   });
 
-  it('walks up to a parent package.json when there is no nearer one', () => {
-    write('package.json', '{}');
-    const file = write('src/deep/agent.ts');
-
-    expect(projectDirFor(file)).toBe(root);
-  });
-
-  it("falls back to the file's own directory when no package.json exists", () => {
-    const file = write('loose/agent.ts');
+  it("falls back to the file's own directory when there is no package.json", () => {
+    const file = path.join(root, 'loose', 'agent.ts');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, '');
 
     expect(projectDirFor(file)).toBe(path.join(root, 'loose'));
   });
 });
 
-describe('tsconfigHasPaths', () => {
-  it('detects path aliases, which Node cannot resolve', () => {
-    write('tsconfig.json', JSON.stringify({ compilerOptions: { paths: { '@/*': ['src/*'] } } }));
-
-    expect(tsconfigHasPaths(root)).toBe(true);
-  });
-
-  it('returns false for a tsconfig without paths', () => {
-    write('tsconfig.json', JSON.stringify({ compilerOptions: { target: 'es2022' } }));
-
-    expect(tsconfigHasPaths(root)).toBe(false);
-  });
-
-  it('returns false when there is no tsconfig at all', () => {
-    expect(tsconfigHasPaths(root)).toBe(false);
-  });
-
-  it('tolerates a malformed tsconfig rather than throwing', () => {
-    write('tsconfig.json', '{ not json');
-
-    expect(tsconfigHasPaths(root)).toBe(false);
-  });
-});
-
 describe('buildRunPlan', () => {
-  it('runs plain CommonJS JavaScript on node with the require preload', () => {
-    write('package.json', '{}');
-    const file = write('agent.js', 'const a = require("a");');
-
-    const plan = buildRunPlan(file, []);
-
-    expect(plan.runner).toBe('node');
-    expect(plan.args).toEqual(['--require', 'monocle2ai/register', file]);
-    expect(plan.cwd).toBe(root);
-  });
-
-  it('runs ESM JavaScript on node with the import preload', () => {
-    write('package.json', JSON.stringify({ type: 'module' }));
-    const file = write('agent.js', 'import a from "a";');
-
-    const plan = buildRunPlan(file, []);
-
-    expect(plan.args).toEqual(['--import', 'monocle2ai/register', file]);
-  });
-
-  it('runs ordinary TypeScript on node, since Node can strip plain types', () => {
+  it('preloads tracing ahead of the target file', () => {
     write('package.json', '{}');
     const file = write('agent.ts', 'const a: string = "x";');
 
-    expect(buildRunPlan(file, []).runner).toBe('node');
+    expect(buildRunPlan(file, []).args).toEqual([
+      '--import',
+      'monocle2ai/register',
+      file,
+    ]);
   });
 
-  it('chooses tsx when the file uses syntax Node cannot strip', () => {
+  it('runs from the project directory, so tsconfig and node_modules resolve', () => {
     write('package.json', '{}');
-    const file = write('agent.ts', 'enum Level { Low }');
+    const file = write('src/agent.ts');
 
-    expect(buildRunPlan(file, []).runner).toBe('tsx');
-  });
-
-  it('chooses tsx when the project uses tsconfig path aliases', () => {
-    write('package.json', '{}');
-    write('tsconfig.json', JSON.stringify({ compilerOptions: { paths: { '@/*': ['src/*'] } } }));
-    const file = write('agent.ts', 'import { a } from "@/lib";');
-
-    expect(buildRunPlan(file, []).runner).toBe('tsx');
-  });
-
-  it('does not force tsx for path aliases when the target is plain JavaScript', () => {
-    write('package.json', '{}');
-    write('tsconfig.json', JSON.stringify({ compilerOptions: { paths: { '@/*': ['src/*'] } } }));
-    const file = write('agent.js', 'const a = 1;');
-
-    expect(buildRunPlan(file, []).runner).toBe('node');
-  });
-
-  it('honours an explicit tsx request', () => {
-    write('package.json', '{}');
-    const file = write('agent.ts', 'const a = 1;');
-
-    expect(buildRunPlan(file, [], { forceTsx: true }).runner).toBe('tsx');
+    expect(buildRunPlan(file, []).cwd).toBe(root);
   });
 
   it('passes the user arguments after the script, so the target sees its own argv', () => {
     write('package.json', '{}');
-    const file = write('agent.js');
+    const file = write('agent.ts');
 
-    const plan = buildRunPlan(file, ['--query', 'hello world']);
-
-    expect(plan.args).toEqual([
+    expect(buildRunPlan(file, ['--query', 'hello world']).args).toEqual([
       '--import',
       'monocle2ai/register',
       file,
@@ -256,267 +113,70 @@ describe('buildRunPlan', () => {
 
     expect(buildRunPlan(file, []).args[0]).toBe('--require');
   });
+
+  it('resolves a relative path, since the child runs from the project directory', () => {
+    write('package.json', '{}');
+    write('agent.ts');
+    const plan = buildRunPlan(path.join(root, '.', 'agent.ts'), []);
+
+    expect(path.isAbsolute(plan.args[2])).toBe(true);
+  });
+
+  // Every module system and TypeScript feature goes through the same plan —
+  // these all failed on plain node before, and the runner no longer varies.
+  it.each([
+    ['enum syntax node cannot strip', 'agent.ts', 'enum Level { Low }'],
+    ['an explicitly-commonjs file using export', 'agent.ts', 'const a = require("a");\nexport {};'],
+    ['a pure ESM file', 'agent.ts', 'import a from "a";'],
+    ['plain JavaScript', 'agent.js', 'const a = require("a");'],
+  ])('handles %s without a separate runner decision', (_label, name, body) => {
+    write('package.json', '{}');
+    const file = write(name, body);
+
+    expect(buildRunPlan(file, []).args[0]).toBe('--import');
+  });
 });
 
 describe('findLocalBin', () => {
-  it('finds a binary in the starting directory node_modules', () => {
+  it('finds a binary in the starting directory', () => {
     const bin = write('node_modules/.bin/tsx', '#!/bin/sh');
 
     expect(findLocalBin('tsx', root)).toBe(bin);
   });
 
-  // npm hoists binaries to the workspace root, so a nested package's cwd will
-  // not contain them.
-  it('walks up to an ancestor node_modules, the way node resolution does', () => {
+  it('walks up to a hoisted binary, as module resolution does', () => {
     const bin = write('node_modules/.bin/tsx', '#!/bin/sh');
-    fs.mkdirSync(path.join(root, 'packages/api/src'), { recursive: true });
+    const nested = path.join(root, 'packages/api');
+    fs.mkdirSync(nested, { recursive: true });
 
-    expect(findLocalBin('tsx', path.join(root, 'packages/api/src'))).toBe(bin);
+    expect(findLocalBin('tsx', nested)).toBe(bin);
   });
 
-  it('returns undefined when the binary is nowhere to be found', () => {
-    fs.mkdirSync(path.join(root, 'empty'), { recursive: true });
-
-    expect(findLocalBin('definitely-not-installed-xyz', path.join(root, 'empty'))).toBeUndefined();
-  });
-});
-
-describe('usesEsmSyntax', () => {
-  it('detects an export statement', () => {
-    expect(usesEsmSyntax('export async function main() {}')).toBe(true);
-  });
-
-  it('detects an import statement', () => {
-    expect(usesEsmSyntax('import OpenAI from "openai";')).toBe(true);
-  });
-
-  it('detects export default', () => {
-    expect(usesEsmSyntax('export default function () {}')).toBe(true);
-  });
-
-  it('does not flag a file using only require and module.exports', () => {
-    const text = 'const a = require("a");\nmodule.exports = { a };';
-
-    expect(usesEsmSyntax(text)).toBe(false);
-  });
-
-  it('does not flag the word export inside a string', () => {
-    expect(usesEsmSyntax('const s = "export this";')).toBe(false);
-  });
-});
-
-describe('packageTypeFor', () => {
-  it('reads an explicit commonjs type', () => {
-    write('package.json', JSON.stringify({ type: 'commonjs' }));
-
-    expect(packageTypeFor(root)).toBe('commonjs');
-  });
-
-  it('reads an explicit module type', () => {
-    write('package.json', JSON.stringify({ type: 'module' }));
-
-    expect(packageTypeFor(root)).toBe('module');
-  });
-
-  it('returns undefined when no type field is set', () => {
-    write('package.json', JSON.stringify({ name: 'x' }));
-
-    expect(packageTypeFor(root)).toBeUndefined();
-  });
-});
-
-describe('buildRunPlan - ESM syntax inside an explicitly CommonJS package', () => {
-  // Node strips types but cannot rewrite `export` into `exports.x`; that is a
-  // transform, not an erasure. With an explicit "type": "commonjs" Node also
-  // refuses to reparse the file as ESM, so it fails outright.
-  it('chooses tsx when an explicitly-commonjs package uses export syntax', () => {
-    write('package.json', JSON.stringify({ type: 'commonjs' }));
-    const file = write('agent.ts', 'const a = require("a");\nexport function go() {}');
-
-    expect(buildRunPlan(file, []).runner).toBe('tsx');
-  });
-
-  it('stays on node for an explicitly-commonjs package written purely in CommonJS', () => {
-    write('package.json', JSON.stringify({ type: 'commonjs' }));
-    const file = write('agent.ts', 'const a = require("a");\nmodule.exports = a;');
-
-    expect(buildRunPlan(file, []).runner).toBe('node');
-  });
-
-  // A package with no "type" lets Node detect ESM syntax and reparse, which works.
-  it('stays on node when the package has no type field', () => {
-    write('package.json', JSON.stringify({ name: 'x' }));
-    const file = write('agent.ts', 'import OpenAI from "openai";');
-
-    expect(buildRunPlan(file, []).runner).toBe('node');
-  });
-
-  it('stays on node for a type:module package', () => {
-    write('package.json', JSON.stringify({ type: 'module' }));
-    const file = write('agent.ts', 'import OpenAI from "openai";');
-
-    expect(buildRunPlan(file, []).runner).toBe('node');
-  });
-
-  it('chooses tsx for a .cts file using export syntax, which is always CommonJS', () => {
-    write('package.json', JSON.stringify({ name: 'x' }));
-    const file = write('agent.cts', 'export function go() {}');
-
-    expect(buildRunPlan(file, []).runner).toBe('tsx');
-  });
-});
-
-describe('isCompilerError - ESM syntax rejected by a CommonJS loader', () => {
-  it("recognises an unexpected export token", () => {
-    expect(isCompilerError("SyntaxError: Unexpected token 'export'")).toBe(true);
-  });
-
-  it('recognises an import statement outside a module', () => {
-    expect(isCompilerError('SyntaxError: Cannot use import statement outside a module')).toBe(true);
-  });
-
-  it('still ignores an ordinary runtime error', () => {
-    expect(isCompilerError('TypeError: undefined is not a function')).toBe(false);
-  });
-});
-
-describe('tsconfigNeedsBundler', () => {
-  // "bundler" resolution lets imports omit file extensions. Node's ESM loader
-  // requires them, so such a project cannot run on plain node.
-  it('detects bundler module resolution', () => {
-    write('tsconfig.json', JSON.stringify({ compilerOptions: { moduleResolution: 'bundler' } }));
-
-    expect(tsconfigNeedsBundler(root)).toBe(true);
-  });
-
-  it('is case-insensitive, since tsconfig values often are', () => {
-    write('tsconfig.json', JSON.stringify({ compilerOptions: { moduleResolution: 'Bundler' } }));
-
-    expect(tsconfigNeedsBundler(root)).toBe(true);
-  });
-
-  it('returns false for nodenext resolution', () => {
-    write('tsconfig.json', JSON.stringify({ compilerOptions: { moduleResolution: 'NodeNext' } }));
-
-    expect(tsconfigNeedsBundler(root)).toBe(false);
-  });
-
-  it('returns false when there is no tsconfig', () => {
-    expect(tsconfigNeedsBundler(root)).toBe(false);
-  });
-});
-
-describe('buildRunPlan - bundler-style projects', () => {
-  it('chooses tsx when the project uses bundler module resolution', () => {
-    write('package.json', JSON.stringify({ type: 'module' }));
-    write('tsconfig.json', JSON.stringify({ compilerOptions: { moduleResolution: 'bundler' } }));
-    const file = write('agent.ts', 'import { a } from "./thing";');
-
-    expect(buildRunPlan(file, []).runner).toBe('tsx');
-  });
-
-  it('leaves plain JavaScript on node even in a bundler project', () => {
-    write('package.json', JSON.stringify({ type: 'module' }));
-    write('tsconfig.json', JSON.stringify({ compilerOptions: { moduleResolution: 'bundler' } }));
-    const file = write('agent.js', 'const a = 1;');
-
-    expect(buildRunPlan(file, []).runner).toBe('node');
+  it('returns undefined when the binary is nowhere up the tree', () => {
+    expect(findLocalBin('tsx', root)).toBeUndefined();
   });
 });
 
 describe('resolveRunnerCommand', () => {
-  it('runs node with the interpreter already executing this CLI', () => {
-    expect(resolveRunnerCommand('node', root)).toEqual({
-      bin: process.execPath,
-      prefixArgs: [],
-    });
-  });
-
   it('prefers a tsx installed in the project', () => {
     const bin = write('node_modules/.bin/tsx', '#!/bin/sh');
 
-    expect(resolveRunnerCommand('tsx', root)).toEqual({ bin, prefixArgs: [] });
+    expect(resolveRunnerCommand(root)).toEqual({ bin, prefixArgs: [] });
   });
 
   // npx resolves tsx from a user-level cache (~/.npm/_npx) and leaves
   // package.json, the lockfile and node_modules untouched — verified.
   it('falls back to npx when tsx is not installed, rather than refusing to run', () => {
-    expect(resolveRunnerCommand('tsx', root)).toEqual({
+    expect(resolveRunnerCommand(root)).toEqual({
       bin: 'npx',
       prefixArgs: ['--yes', 'tsx'],
     });
   });
 
   it('reports whether the fallback is in use so the CLI can say so', () => {
-    expect(resolveRunnerCommand('tsx', root).bin).toBe('npx');
+    expect(resolveRunnerCommand(root).bin).toBe('npx');
 
     write('node_modules/.bin/tsx', '#!/bin/sh');
-    expect(resolveRunnerCommand('tsx', root).bin).not.toBe('npx');
-  });
-});
-
-describe('buildRunPlan - files that mix require() with ESM syntax', () => {
-  // Node parses a typeless file as CommonJS first, then reparses it as ESM the
-  // moment it spots module syntax. That rescue is what makes a pure-ESM file
-  // work — and what breaks a file that also calls require(), since `require`
-  // does not exist in ESM scope. tsx compiles both forms down to CommonJS.
-  const MIXED = "require('dotenv/config');\nconst { a } = require('a');\nexport {};";
-
-  it('chooses tsx for a typeless package whose file mixes require with export', () => {
-    write('package.json', JSON.stringify({ name: 'x' }));
-    const file = write('agent.ts', MIXED);
-
-    expect(buildRunPlan(file, []).runner).toBe('tsx');
-  });
-
-  it('chooses tsx when the ESM marker is a bare `export {}` at the end of the file', () => {
-    write('package.json', JSON.stringify({ name: 'x' }));
-    const file = write('agent.ts', "const a = require('a');\na();\nexport {};");
-
-    expect(buildRunPlan(file, []).runner).toBe('tsx');
-  });
-
-  it('chooses tsx for a type:module package whose file calls require', () => {
-    write('package.json', JSON.stringify({ type: 'module' }));
-    const file = write('agent.ts', "const a = require('a');\nexport {};");
-
-    expect(buildRunPlan(file, []).runner).toBe('tsx');
-  });
-
-  it('chooses tsx for a type:module package written entirely in CommonJS', () => {
-    // No ESM syntax to trigger a reparse, but "type": "module" already forces
-    // ESM, so require is undefined here too.
-    write('package.json', JSON.stringify({ type: 'module' }));
-    const file = write('agent.ts', "const a = require('a');\nmodule.exports = a;");
-
-    expect(buildRunPlan(file, []).runner).toBe('tsx');
-  });
-
-  it('stays on node for a typeless package written purely in ESM', () => {
-    write('package.json', JSON.stringify({ name: 'x' }));
-    const file = write('agent.ts', "import OpenAI from 'openai';\nexport {};");
-
-    expect(buildRunPlan(file, []).runner).toBe('node');
-  });
-
-  it('stays on node for a typeless package written purely in CommonJS', () => {
-    write('package.json', JSON.stringify({ name: 'x' }));
-    const file = write('agent.ts', "const a = require('a');\nmodule.exports = a;");
-
-    expect(buildRunPlan(file, []).runner).toBe('node');
-  });
-
-  it('does not mistake the word require inside an identifier for a call', () => {
-    write('package.json', JSON.stringify({ type: 'module' }));
-    const file = write('agent.ts', "const requireAuth = true;\nexport { requireAuth };");
-
-    expect(buildRunPlan(file, []).runner).toBe('node');
-  });
-
-  it('does not mistake a string mentioning require for a call', () => {
-    write('package.json', JSON.stringify({ type: 'module' }));
-    const file = write('agent.ts', "export const hint = 'use require() instead';");
-
-    expect(buildRunPlan(file, []).runner).toBe('node');
+    expect(resolveRunnerCommand(root).bin).not.toBe('npx');
   });
 });

--- a/test/unit/envFile.test.ts
+++ b/test/unit/envFile.test.ts
@@ -33,16 +33,38 @@ describe('loadMonocleEnvFile', () => {
     expect(process.env.MONOCLE_WORKFLOW_NAME).toBe('my-agent');
   });
 
-  // The app's own .env is loaded by Node before startup and CI sets real
-  // variables, so this file is the lowest priority of the three.
-  it('leaves a variable that is already set alone', () => {
+  // This file is where Monocle's settings live, so it is authoritative. It
+  // has to override: the preload runs in every process tsx spawns, and only
+  // the last of them applies --env-file, so leaving set variables alone made
+  // .env win under plain node and lose under tsx for the very same project.
+  it('overrides a variable that is already set', () => {
     process.env.MONOCLE_EXPORTER = 'okahu';
     writeEnvFile('MONOCLE_EXPORTER=file\nMONOCLE_DEBUG=true\n');
 
     loadMonocleEnvFile(root);
 
-    expect(process.env.MONOCLE_EXPORTER).toBe('okahu');
+    expect(process.env.MONOCLE_EXPORTER).toBe('file');
     expect(process.env.MONOCLE_DEBUG).toBe('true');
+  });
+
+  it('leaves variables the file does not mention alone', () => {
+    process.env.MONOCLE_DEBUG = 'true';
+    writeEnvFile('MONOCLE_EXPORTER=file\n');
+
+    loadMonocleEnvFile(root);
+
+    expect(process.env.MONOCLE_DEBUG).toBe('true');
+  });
+
+  // Parsed with Node's own rules, so this file and --env-file never disagree
+  // about what a line means.
+  it('parses the file the way --env-file does', () => {
+    writeEnvFile('export MONOCLE_EXPORTER=file\n# a comment\nMONOCLE_FILE_PREFIX="two words"\n');
+
+    loadMonocleEnvFile(root);
+
+    expect(process.env.MONOCLE_EXPORTER).toBe('file');
+    expect(process.env.MONOCLE_FILE_PREFIX).toBe('two words');
   });
 
   it('reads the file beside the directory it is given, not the process cwd', () => {

--- a/test/unit/envFile.test.ts
+++ b/test/unit/envFile.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { loadMonocleEnvFile, MONOCLE_ENV_FILE } from '../../src/common/envFile';
+
+let root: string;
+let savedEnv: NodeJS.ProcessEnv;
+
+const writeEnvFile = (body: string) =>
+  fs.writeFileSync(path.join(root, MONOCLE_ENV_FILE), body);
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'monocle-envfile-'));
+  savedEnv = { ...process.env };
+});
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+  // Restore in place: reassigning process.env swaps Node's special env object
+  // for a plain one, and loadEnvFile then writes where nothing can read it.
+  for (const key of Object.keys(process.env)) {
+    if (!(key in savedEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, savedEnv);
+});
+
+describe('loadMonocleEnvFile', () => {
+  it('puts the settings it reads on process.env', () => {
+    writeEnvFile('MONOCLE_EXPORTER=file\nMONOCLE_WORKFLOW_NAME=my-agent\n');
+
+    expect(loadMonocleEnvFile(root)).toBe('loaded');
+    expect(process.env.MONOCLE_EXPORTER).toBe('file');
+    expect(process.env.MONOCLE_WORKFLOW_NAME).toBe('my-agent');
+  });
+
+  // The app's own .env is loaded by Node before startup and CI sets real
+  // variables, so this file is the lowest priority of the three.
+  it('leaves a variable that is already set alone', () => {
+    process.env.MONOCLE_EXPORTER = 'okahu';
+    writeEnvFile('MONOCLE_EXPORTER=file\nMONOCLE_DEBUG=true\n');
+
+    loadMonocleEnvFile(root);
+
+    expect(process.env.MONOCLE_EXPORTER).toBe('okahu');
+    expect(process.env.MONOCLE_DEBUG).toBe('true');
+  });
+
+  it('reads the file beside the directory it is given, not the process cwd', () => {
+    writeEnvFile('MONOCLE_WORKFLOW_NAME=from-dir\n');
+
+    loadMonocleEnvFile(root);
+
+    expect(process.env.MONOCLE_WORKFLOW_NAME).toBe('from-dir');
+  });
+
+  // Most projects will never have this file; that is not a problem to report.
+  it('reports an absent file without throwing', () => {
+    expect(loadMonocleEnvFile(root)).toBe('absent');
+  });
+
+  // Tracing must never fail because this optional file cannot be read.
+  it('reports a file it cannot read without throwing', () => {
+    fs.mkdirSync(path.join(root, MONOCLE_ENV_FILE));
+
+    expect(loadMonocleEnvFile(root)).toBe('failed');
+  });
+
+  it('defaults to the process cwd', () => {
+    expect(() => loadMonocleEnvFile()).not.toThrow();
+  });
+});

--- a/test/unit/esmModule.test.ts
+++ b/test/unit/esmModule.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { registerMock } = vi.hoisted(() => ({ registerMock: vi.fn() }));
+vi.mock('module', () => ({ register: registerMock }));
+
+import { registerModule } from '../../src/instrumentation/common/esmModule';
+
+/** The `data.exclude` patterns handed to import-in-the-middle. */
+function excludePatterns(): RegExp[] {
+  const call = registerMock.mock.calls[0];
+  expect(call, 'register() was never called').toBeDefined();
+  return call[2]?.data?.exclude ?? [];
+}
+
+const matches = (url: string) => excludePatterns().some((re) => re.test(url));
+
+describe('registerModule - TypeScript sources are excluded from IITM', () => {
+  beforeEach(() => {
+    registerMock.mockClear();
+    registerModule();
+  });
+
+  // Without this, IITM intercepts .ts files before Node strips their types,
+  // and any TypeScript syntax reaches V8 raw as a SyntaxError.
+  it('excludes .ts files', () => {
+    expect(matches('file:///app/agent.ts')).toBe(true);
+  });
+
+  it('excludes .tsx files', () => {
+    expect(matches('file:///app/page.tsx')).toBe(true);
+  });
+
+  it('excludes .mts files', () => {
+    expect(matches('file:///app/agent.mts')).toBe(true);
+  });
+
+  it('excludes .cts files', () => {
+    expect(matches('file:///app/agent.cts')).toBe(true);
+  });
+
+  it('excludes a .ts url carrying a query string', () => {
+    expect(matches('file:///app/agent.ts?v=2')).toBe(true);
+  });
+
+  // The whole point of the hook is to wrap dependencies, which ship as .js.
+  it('does NOT exclude .js files, which are what we need to wrap', () => {
+    expect(matches('file:///app/node_modules/openai/index.js')).toBe(false);
+  });
+
+  it('does NOT exclude .mjs files', () => {
+    expect(matches('file:///app/node_modules/openai/index.mjs')).toBe(false);
+  });
+
+  it('does NOT exclude .cjs files', () => {
+    expect(matches('file:///app/node_modules/openai/index.cjs')).toBe(false);
+  });
+
+  it('does NOT exclude a package whose name merely contains ts', () => {
+    expect(matches('file:///app/node_modules/ts-utils/index.js')).toBe(false);
+  });
+
+  it('still registers the import-in-the-middle hook', () => {
+    expect(registerMock.mock.calls[0][0]).toBe('import-in-the-middle/hook.mjs');
+  });
+});
+
+// openai v4 keeps its runtime shims in module-level state: _shims/index.mjs
+// calls setShims() on _shims/registry.mjs, and core.mjs then reads it back.
+// Wrapping those modules gives the writer and the reader different instances,
+// so core.mjs sees an uninitialised registry and throws
+// "you must `import 'openai/shims/node'` before importing anything else".
+describe('registerModule - openai runtime shims are excluded', () => {
+  beforeEach(() => {
+    registerMock.mockClear();
+    registerModule();
+  });
+
+  it('excludes the openai shims registry', () => {
+    expect(matches('file:///app/node_modules/openai/_shims/registry.mjs')).toBe(true);
+  });
+
+  it('excludes the openai shims index', () => {
+    expect(matches('file:///app/node_modules/openai/_shims/index.mjs')).toBe(true);
+  });
+
+  it('excludes the auto-runtime shim', () => {
+    expect(matches('file:///app/node_modules/openai/_shims/auto/runtime.mjs')).toBe(true);
+  });
+
+  // The whole point of the hook is to wrap this one — excluding it would
+  // silently disable OpenAI tracing.
+  it('does NOT exclude the chat completions module we actually patch', () => {
+    expect(matches('file:///app/node_modules/openai/resources/chat/completions.mjs')).toBe(false);
+  });
+
+  it('does NOT exclude openai core', () => {
+    expect(matches('file:///app/node_modules/openai/core.mjs')).toBe(false);
+  });
+
+  it('does NOT exclude an unrelated package with shims in its path', () => {
+    expect(matches('file:///app/node_modules/other/_shims/registry.mjs')).toBe(false);
+  });
+});

--- a/test/unit/exporters.test.ts
+++ b/test/unit/exporters.test.ts
@@ -21,10 +21,18 @@ describe('getMonocleExporters', () => {
         process.env = originalEnv;
     });
 
-    it('should return console exporter by default when no MONOCLE_EXPORTER is set', () => {
+    // Spans printed to the terminal are lost the moment the scrollback rolls;
+    // written to .monocle/ they survive the run and can be read back.
+    it('should return file exporter by default when no MONOCLE_EXPORTER is set', () => {
         delete process.env.MONOCLE_EXPORTER;
         const exporters = getMonocleExporters();
         expect(exporters).toHaveLength(1);
+        expect(exporters[0]).toBeInstanceOf(FileSpanExporter);
+    });
+
+    it('should still use console when MONOCLE_EXPORTER asks for it', () => {
+        process.env.MONOCLE_EXPORTER = 'console';
+        const exporters = getMonocleExporters();
         expect(exporters[0]).toBeInstanceOf(MonocleConsoleSpanExporter);
     });
 

--- a/test/unit/setupIdempotent.test.ts
+++ b/test/unit/setupIdempotent.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { setupMonocle } from '../../src/instrumentation/common/instrumentation';
+
+const INSTRUMENTOR = Symbol.for('monocle2ai.instrumentor');
+
+// Running an already-instrumented file under `monocle2ai run` calls
+// setupMonocle twice: once from the preload, once from the file's own injected
+// setup. Without a guard that builds two tracer providers and every span is
+// exported twice.
+describe('setupMonocle is idempotent', () => {
+  afterEach(() => {
+    delete (globalThis as any)[INSTRUMENTOR];
+  });
+
+  it('returns the existing instrumentor instead of setting up again', () => {
+    const first = setupMonocle('workflow-one');
+    const second = setupMonocle('workflow-two');
+
+    expect(second).toBe(first);
+  });
+
+  it('leaves the first setup in place on the global', () => {
+    const first = setupMonocle('workflow-one');
+    setupMonocle('workflow-two');
+
+    expect((globalThis as any)[INSTRUMENTOR]).toBe(first);
+  });
+
+  it('sets up normally when nothing has been set up yet', () => {
+    const only = setupMonocle('workflow-one');
+
+    expect(only).toBeDefined();
+    expect((globalThis as any)[INSTRUMENTOR]).toBe(only);
+  });
+});


### PR DESCRIPTION
## Proposed changes

Adds `monocle2ai run <file>`, a CLI that traces a script without editing it, plus the loader fixes it depends on and the settings file it reads.

Today, tracing a file means adding `setupMonocle()` to the source and getting that call ordered ahead of every traced import. This preloads tracing before the target loads instead, so the file needs no source changes:

```bash
npx monocle2ai run src/agent.ts
```

Everything runs through tsx, which handles every module system and TypeScript feature Node's strip-only mode cannot. The preload flag is `--import`, except for `.cts` targets where import-in-the-middle throws `is not in cache`. When tsx isn't installed the CLI falls back to `npx --yes tsx` rather than refusing — npx serves it from a user-level cache and leaves `package.json`, the lockfile and `node_modules` untouched.

Monocle's own settings move out of the application's `.env` and into `.env.monocle`, which Monocle reads for itself.

### Loader fixes

**`fix: exclude TypeScript sources and openai shims from import-in-the-middle`**
IITM claims `.ts` files on Node's CommonJS-then-reparse path, before native type stripping runs, so TypeScript syntax reaches V8 and throws. Wrapping openai v4's `_shims` also splits its module-level registry between writer and reader, making `core.mjs` throw on an uninitialised registry. Neither is instrumented, so excluding both costs no coverage.

**`fix: make setupMonocle idempotent per process`**
A preloaded register entry plus an in-file `setupMonocle` call would build a second tracer provider and export every span twice. Returns the existing instrumentor instead — placed after argument validation so the conflicting-arguments error still fires.

### The CLI

**`feat: add monocle2ai run CLI to trace a file without editing it`**
The CLI, its argument parsing, the run plan, and the `bin` entry in the published package.

**`refactor: always run through tsx and drop the node runner`**
The first version defaulted to Node and escalated to tsx via heuristics — tsconfig probing, package-type lookup, TypeScript syntax detection, and a retry to recover from a wrong guess. Measured against eight real entry files, Node was chosen for two, and both run identically under tsx. The heuristics cost ~180 lines to save ~170ms of a multi-second tracing startup, so they're gone: **−731 lines, +105.**

**`fix: run tsx through node rather than its .bin shim`**
On Windows the runner resolved to `node_modules\.bin\tsx.cmd`, and since CVE-2024-27980 libuv refuses to spawn a `.cmd` or `.bat` without a shell, returning `EINVAL` — the target never started. Monocle now resolves tsx's own JS entry from its package manifest and hands it to the node binary already running, so no shim is spawned and the result no longer varies by platform. The npx fallback goes the same way, through npm's `npx-cli.js`, since `npx` on Windows is `npx.cmd` and failed identically.

The `spawn` call is guarded too. Node emits only `EACCES`, `EAGAIN`, `EMFILE`, `ENFILE` and `ENOENT` as `error` events and **throws** the rest, so `EINVAL` escaped the promise executor and reached the user as a raw Node stack instead of the install guidance the CLI already had ready.

### Settings

**`feat: read Monocle settings from .env.monocle`** and **`fix: make .env.monocle authoritative for Monocle settings`**

Monocle's settings no longer live in the application's `.env`. `setupMonocle` loads `.env.monocle` itself, which means the settings also reach Next.js and mastra — neither passes `--env-file`, but both go through `setupMonocle`.

The file is authoritative: its values replace what is already in the environment. Deferring to variables already set made precedence depend on the runner. The preload runs in every process tsx spawns and only the last of them applies `--env-file`, so a key set in both files won under plain `node` and lost under `tsx`, in the same project. It is parsed with Node's own `.env` parser (`util.parseEnv`), so this file and `--env-file` cannot disagree about what a line means.

The deliberate cost: a `MONOCLE_*` variable exported in the shell no longer overrides the file.

**`fix: reach util.parseEnv through the namespace, not a named import`**
A named ESM import of a builtin export that does not exist is a load-time `SyntaxError`, so on Node older than 20.12 the preload would have died on the import rather than reaching the guard meant to skip the settings file there.

**`feat: default to the file exporter when none is configured`**
Spans printed to a terminal are gone once the scrollback rolls, and a run started from an editor may have no visible terminal at all. Unconfigured runs now write to `.monocle/` instead, where the trace can be read back after the run. Console remains one `MONOCLE_EXPORTER=console` away, and an unrecognised exporter name still falls back to it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

The breaking item is the default exporter. A caller that set no `MONOCLE_EXPORTER` and read spans from stdout now finds an empty terminal and JSON files in `.monocle/`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

**Testing.** 385 unit tests pass. Verified end-to-end against six real projects, each of which exposed a distinct bug during development: `langchain-openai-cjs` (explicit `commonjs` + `export`), `langchain-openai-esm` (openai v4 `_shims`), `mastra-ai-agent-demo` (bundler resolution), `adk-travel-agent-typescript` (`require` + `export {}` in a typeless package), plus `langchain-anthropic-cjs` and `langchain-gemini-cjs`. Also covered: an interactive agent reading from the terminal, and a project with no tsx installed exercising the npx fallback.

Settings precedence was verified across both runners on one project with the same key in `.env` and `.env.monocle`: `tsx` and `node` now agree.

**Windows.** The `.cmd` resolution is covered by unit tests that simulate `win32`, and the guarded spawn is tested through `ENOTDIR` — a path whose parent is a file, which Node also throws rather than emits, reproducing the same failure class off Windows. The original `EINVAL` was reported from a Windows machine and the replacement command was confirmed working there by hand.

**Why tsx unconditionally.** Startup is `6.75s` under tsx versus `6.58s` under Node — the difference is 2.5%, and the remaining 6.6s is Monocle's own instrumentation loading. Choosing between them was not worth a decision procedure that could be wrong. The trade-off is that tsx becomes a hard requirement; the npx fallback covers projects that don't have it, so no project needs to add a dependency.

**Why `monocle2ai run` rather than documenting `--import monocle2ai/register`.** One interface to learn, and it keeps preload and runner details inside the package where they can change without users changing their commands. Error messages deliberately point back at `monocle2ai run` rather than at the preload.

**Known limitations.**

*Files with no top-level execution.* A module that only defines and exports — a service class, an agent definition, a helper — loads, exits 0, and traces nothing, with no output at all. There's no error because nothing went wrong; the file simply had nothing to run. Whether a file is an entry point can't be determined statically (a file may export freely and still be an entry point, or guard itself with `require.main === module`), so the CLI doesn't try to gate on it. A span-count summary at exit would make the no-op visible, and isn't in this PR.

*Framework-owned entry points.* Next.js route handlers and pages, and Vite/CRA browser code, are started by the framework, not by running the file. `monocle2ai run` will execute such a file, but the result won't resemble the running app. Instrumenting these needs the framework's own entry point — `monocle2ai/next` for Next.js.

*The application's `.env` is still not loaded.* The CLI does not pass `--env-file`, so a project whose npm script relies on `tsx --env-file=.env` will see its own variables undefined when run through the CLI — `.env.monocle` covers Monocle's settings, not the application's. Files that call `require('dotenv/config')` themselves are unaffected. Export the variables in the shell, or load them in-process.

*`.env.monocle` needs Node 20.12 or 21.7.* `util.parseEnv` arrived there. On older runtimes the file is skipped and settings must come from the environment.
